### PR TITLE
Add coverage badge to readme

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source =
+    src
+    tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ install:
 # commands to run tests 
 script:
   - - black --check . --exclude docs/
-  - pytest
+  - coverage run -m pytest
 
+after_success:
+  - COVERALLS_REPO_TOKEN=${{ secrets.coverage_token }} coveralls
 #  - pylint */*.py
 #jobs:
 #  include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 
 ### Added
 - tests for the A0 module (#87)
+- badge for coveralls.io (#90)
 ### Changed 
 - removed unused class structure in all modules, execution stay the same (#86)
 ### Removed

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/mvs-eland/badge/?version=latest)](https://mvs-eland.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/smartie2076/mvs_eland.svg?branch=dev)](https://travis-ci.org/smartie2076/mvs_eland)
+[![Coverage Status](https://coveralls.io/repos/github/rl-institut/mvs_eland/badge.svg?branch=dev)](https://coveralls.io/github/rl-institut/mvs_eland?branch=dev)
 
 Rights: [Reiner Lemoine Institut (Berlin)](https://reiner-lemoine-institut.de/)
 

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -3,3 +3,5 @@ pygraphviz==1.5
 black==19.10b0
 graphviz==0.13
 sphinx==2.2.2
+coverage==4.5
+python-coveralls==2.9.3


### PR DESCRIPTION
Fix #54

To link travis and coveralls.io

```
script: "add here the code for coverage test"

after_success: "add here code to send coveralls test results"
```

Description of steps:
- `pip install coverage==4.5`
- `python-coveralls`
    Note : the version > 5 of `coverage` is not compatible with `python-coveralls`, so version 4.5 was chosen.
- open a [coveralls.io](https://coveralls.io) account with signup from github
- look for the `repo_token` on the [mvs_eland repo](https://coveralls.io/github/rl-institut/mvs_eland) on coveralls.io
- copy this into the [secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) of the mvs_eland repository on github (Settings-->Secrets-->Add a new secret), with secret name `coverage_token`

Some help can be found [here](https://github.com/z4r/python-coveralls)

If the github secret's do not work, a solution could be to use [encrypted keys](https://docs.travis-ci.com/user/encryption-keys/) from travis