### PR TITLE
[Draft] Delete parameters in "simulation_settings.csv"

### DIFF
--- a/inputs/elements/csv/simulation_settings.csv
+++ b/inputs/elements/csv/simulation_settings.csv
@@ -1,16 +1,15 @@
 ,unit,simulation_settings
-display_output,str,-debug
-evaluated_period,days,365
-input_file_name,str,test_input_file_v1.xlsx
 label,str,simulation_settings
-oemof_file_name,str,MVS_results.oemof
+display_output,str,-debug
 output_lp_file,str,False
 overwrite,str,True
-path_input_file,str,./inputs/test_input_file_v1.xlsx
+store_oemof_results,str,True
+restore_from_oemof_file,str,True
+evaluated_period,days,365
+start_date,str,2018-01-01 00:00:00
+timestep,minutes,60
+oemof_file_name,str,MVS_results.oemof
 path_input_folder,str,./inputs/
 path_output_folder,str,./MVS_outputs
 path_output_folder_inputs,str,./MVS_outputs/inputs/
-restore_from_oemof_file,str,True
-start_date,str,2018-01-01 00:00:00
-store_oemof_results,str,True
-timestep,minutes,60
+


### PR DESCRIPTION
Deleted: 
input_file_name	str	test_input_file_v1.xlsx
path_input_file	str	./inputs/test_input_file_v1.xlsx

Further, some of these parameters could be deleted (but might be necessary to set as defaults):
oemof_file_name,str,MVS_results.oemof
path_output_folder_inputs,str,./MVS_outputs/inputs/

-> changes still need to be applied to A1 as well.

-> this is a draft PR! (did not know how to update)

Fix #98 