### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,12 @@ Here is a template for new release sections
 ### Added
 
 ### Changed
+- Give priority from kwargs on command line arguments (#112)
 
 ### Removed
+
+### Fixed
+- Input directory of csv files specified by user is handed to `load_data_from_csv.create_input_json()` (#112)
 
 ## [0.1.0] -2020-01-30
 

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -62,6 +62,7 @@ def main(**kwargs):
     # Parse the arguments from the command line
     parser = initializing.create_parser()
     args = vars(parser.parse_args())
+    # Give priority from kwargs on command line arguments
     args.update(**kwargs)
     kwargs = args
 

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -74,7 +74,9 @@ def main(**kwargs):
 
     if not user_input["path_input_file"].endswith("json"):
         logging.debug("Accessing script: A1_csv_to_json")
-        path_to_json_from_csv = load_data_from_csv.create_input_json()
+        path_to_json_from_csv = load_data_from_csv.create_input_json(
+            input_directory=user_input["path_input_folder"]
+        )
         user_input.update({"path_input_file": path_to_json_from_csv})
 
     logging.debug("Accessing script: B0_data_input_json")

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -62,7 +62,8 @@ def main(**kwargs):
     # Parse the arguments from the command line
     parser = initializing.create_parser()
     args = vars(parser.parse_args())
-    kwargs.update(**args)
+    args.update(**kwargs)
+    kwargs = args
 
     logging.debug("Accessing script: A0_initialization")
     user_input = initializing.welcome(welcome_text, **kwargs)


### PR DESCRIPTION
This PR contains two minor fixes:

- `**kwargs` of `main()` were overwritten by default parameters - I changed the order of updating.
- Input directory of csv files specified by user is handed to `load_data_from_csv.create_input_json()`