### PR TITLE
Bugfix: Enable multiple inputs/outputs

### DIFF
--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -939,7 +939,7 @@ def receive_timeseries_from_csv(settings, dict_asset, type):
     file_path = os.path.join(settings["path_input_folder"], TIME_SERIES, file_name)
     verify.lookup_file(file_path, dict_asset["label"])
 
-    data_set = pd.read_csv(file_path, sep=";")
+    data_set = pd.read_csv(file_path, sep=",")
 
     if "file_name" in dict_asset:
         header = data_set.columns[0]
@@ -1095,7 +1095,7 @@ def get_timeseries_multiple_flows(settings, dict_asset, file_name, header):
     -------
 
     """
-    file_path = os.path.join(settings["path_input_folder"], file_name)
+    file_path = os.path.join(settings["path_input_folder"], TIME_SERIES, file_name)
     verify.lookup_file(file_path, dict_asset["label"])
 
     data_set = pd.read_csv(file_path, sep=";")

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -372,7 +372,7 @@ def source_non_dispatchable_fix(model, dict_asset, **kwargs):
                 actual_value=dict_asset["timeseries"],
                 fixed=True,
                 nominal_value=dict_asset["installedCap"]["value"],
-                variable_costs=dict_asset["opex_var"][0],
+                variable_costs=dict_asset["opex_var"]["value"][index],
             )
             index += 1
     else:

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,6 +1,6 @@
 import os
 
-# name of the folder containing mvs model described by .csv_elements
+# name of the folder containing mvs model described by ".csv" files
 CSV_ELEMENTS = "csv_elements"
 # name of the folder containing the copied content of the input folder within the output folder
 INPUTS_COPY = "inputs"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,6 +1,6 @@
 import os
 
-# name of the folder containing mvs model described by .csv files
+# name of the folder containing mvs model described by .csv_elements
 CSV_ELEMENTS = "csv_elements"
 # name of the folder containing the copied content of the input folder within the output folder
 INPUTS_COPY = "inputs"


### PR DESCRIPTION
Solution: File path for multiple inputs missed TIME_SERIES
`
file_path = os.path.join(settings["path_input_folder"], TIME_SERIES, file_name)`

Closes #163 