### PR TITLE
Feature/input parameters not setted in csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Here is a template for new release sections
 Terminal commands changed (#135)
 ### Removed
 - Function welcome from module A0 (#138)
+- Parameters `input_file_name`, `overwrite`, `path_input_file`, `path_input_folder`, `path_input_sequences`, `path_output_folder`, `path_output_folder_inputs` from `simulation_settings.csv` (#178)
 ### Fixed
 - Input directory of csv files specified by user is handed to `load_data_from_csv.create_input_json()` (#112)
 - \#111 & \#114 fix user choice of output folder via command line arguments(#115)

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ For more information about the possible command lines
 
 Edit the json (or csv files) and run the `main()` function. The following `kwargs` are possible:
 
-- **overwrite** (bool): Determines whether to replace existing results in `path_output_folder` with the results of the current simulation (True) or not (False). Default: `False`.
-- **input_type** (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.
-- **path_input_folder** (str): The path to the directory where the input CSVs/JSON files are located. Default: `inputs/`.
-- **path_output_folder** (str): The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. Default: `MVS_outputs/`.
+- `overwrite` (bool): Determines whether to replace existing results in `path_output_folder` with the results of the current simulation (True) or not (False). Default: `False`.
+- `input_type` (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.
+- `path_input_folder` (str): The path to the directory where the input CSVs/JSON files are located. Default: `inputs/`.
+- `path_output_folder` (str): The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. Default: `MVS_outputs/`.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For more information about the possible command lines
 
 ##### 2) Use the `main()` function
 
-Edit the json (or csv files) and run the `main()` function. The following `kwargs` are possible:
+Edit the csv files (or, for devs, the json file) and run the `main()` function. The following `kwargs` are possible:
 
 - `overwrite` (bool): Determines whether to replace existing results in `path_output_folder` with the results of the current simulation (True) or not (False). Default: `False`.
 - `input_type` (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.

--- a/README.md
+++ b/README.md
@@ -88,17 +88,34 @@ To set up the MVS, follow the steps below:
     
 ## Using the MVS
 
-To run the MVS with custom inputs, edit the json input file and run
+To run the MVS with custom inputs you have several options:
 
-    `python mvs_tool.py -i path_input_file -o path_output_folder`
+##### 1) Use the command line
 
-With `path_input_file`: path to json input file
+Edit the json input file (or csv files) and run
 
-and `path_output_folder`: path of the folder where simulation results should be stored
+    `python mvs_tool.py -i path_input_file -ext json -o path_output_folder`
+
+With 
+`path_input_file`: path to json input file,
+
+`ext`: json for using a json file and csv for using csv files
+
+and `path_output_folder`: path of the folder where simulation results should be stored.
 
 For more information about the possible command lines
 
 `python mvs_tool.py -h`
+
+##### 1) Use the `main()` function
+
+Edit the json (or csv files) and run the `main()` function. The following `kwargs` are possible:
+
+- **overwrite** (bool): Determines whether to replace existing results in `path_output_folder` with the results of the current simulation (True) or not (False). Default: `False`.
+- **input_type** (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.
+- **path_input_folder** (str): The path to the directory where the input CSVs/JSON files are located. Default: `inputs/`.
+- **path_output_folder** (str): The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. Default: `MVS_outputs/`.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For more information about the possible command lines
 
 `python mvs_tool.py -h`
 
-##### 1) Use the `main()` function
+##### 2) Use the `main()` function
 
 Edit the json (or csv files) and run the `main()` function. The following `kwargs` are possible:
 

--- a/docs/MVS_parameters.rst
+++ b/docs/MVS_parameters.rst
@@ -42,7 +42,7 @@ simulation_settings.csv
 
 **output_lp_file**: Acceptable values are either True or False. Entering True would result in the generation of a file with the linear equation system describing the simulation, ie., with the objective function and all the constraints. This lp file enables the user to peer ‘under the hood’ to understand how the program optimizes for the solution.
 
-**restore_from_oemof_file**: [Developer setting] Allows the developer to check the OEMOF file where the results are stored and edit the simulation parameters in it. 
+**restore_from_oemof_file**: [Developer setting] Allows the developer to check the OEMOF file where the results are stored and edit the simulation parameters in it. (not integrated yet!)
 
 **start_date**: The data and time on which the simulation starts at the first step. Acceptable format is YYYY-MM-DD HH:MM:SS. E.g.: 2018-01-01 00:00:00
 

--- a/docs/MVS_parameters.rst
+++ b/docs/MVS_parameters.rst
@@ -40,16 +40,7 @@ simulation_settings.csv
 
 **oemof_file_name**: The name of the OEMOF file in which the simulation results are stored. 
 
-**output_lp_file**: Acceptable values are either True or False. Entering True would result in the generation of a file with the linear equation system describing the simulation, ie., with the objective function and all the constraints. This lp file enables the user to peer ‘under the hood’ to understand how the program optimizes for the solution. 
-
-**overwrite**: Acceptable values are either True or False. Entering True would result in the existing values in the output files of the previous simulation being replaced with the values generated in the current simulation.
-
-**path_input_folder**: The path to the directory where the CSVs/JSON files are located. By default, the input directory path is: inputs/
-
-**input_type**: Whether the input is from the `mvs_config.json` file ("json") or from csv files
-located within <path_input_folder>/csv_elements/
-
-**path_output_folder**: The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. By default, the output directory path is: MVS_outputs/
+**output_lp_file**: Acceptable values are either True or False. Entering True would result in the generation of a file with the linear equation system describing the simulation, ie., with the objective function and all the constraints. This lp file enables the user to peer ‘under the hood’ to understand how the program optimizes for the solution.
 
 **restore_from_oemof_file**: [Developer setting] Allows the developer to check the OEMOF file where the results are stored and edit the simulation parameters in it. 
 

--- a/inputs/csv_elements/simulation_settings.csv
+++ b/inputs/csv_elements/simulation_settings.csv
@@ -1,16 +1,9 @@
 ,unit,simulation_settings
 display_output,str,-debug
 evaluated_period,days,365
-input_file_name,str,test_input_file_v1.xlsx
 label,str,simulation_settings
 oemof_file_name,str,MVS_results.oemof
 output_lp_file,str,False
-overwrite,str,True
-path_input_file,str,./inputs/test_input_file_v1.xlsx
-path_input_folder,str,./inputs/
-path_input_sequences,str,./inputs/sequences/
-path_output_folder,str,./MVS_outputs
-path_output_folder_inputs,str,./MVS_outputs/inputs/
 restore_from_oemof_file,str,True
 start_date,str,2018-01-01 00:00:00
 store_oemof_results,str,True

--- a/inputs/csv_elements/simulation_settings.csv
+++ b/inputs/csv_elements/simulation_settings.csv
@@ -1,5 +1,4 @@
 ,unit,simulation_settings
-display_output,str,-debug
 evaluated_period,days,365
 label,str,simulation_settings
 oemof_file_name,str,MVS_results.oemof

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -45,6 +45,28 @@ from src.constants import CSV_ELEMENTS, CSV_FNAME, CSV_EXT
 
 def main(**kwargs):
     # Display welcome text
+    r"""
+    Starts MVS tool simulations.
+
+    Other Parameters
+    ----------------
+    overwrite : bool
+        Determines whether to replace existing results in `path_output_folder`
+        with the results of the current simulation (True) or not (False).
+        Default: False.
+    input_type : str
+        Defines whether the input is taken from the `mvs_config.json` file
+        ("json") or from csv files ('csv') located within
+        <path_input_folder>/csv_elements/. Default: 'json'.
+    path_input_folder : str
+        The path to the directory where the input CSVs/JSON files are located.
+        Default: 'inputs/'.
+    path_output_folder : str
+        The path to the directory where the results of the simulation such as
+        the plots, time series, results JSON files are saved by MVS E-Lands.
+        Default: 'MVS_outputs/'
+
+    """
     version = (
         "0.1.1"  # update_me Versioning scheme: Major release.Minor release.Patches
     )

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -174,14 +174,10 @@ def create_input_json(
     parameterlist.update(
         {
             "simulation_settings": [
-                "display_output",
                 "evaluated_period",
                 "label",
                 "oemof_file_name",
                 "output_lp_file",
-                "overwrite",
-                "path_input_folder",
-                "path_output_folder",
                 "restore_from_oemof_file",
                 "plot_nx_graph",
                 "start_date",

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -17,15 +17,13 @@ def load_json(
 
     # The user specified a value
     if path_input_folder is not None:
-        dict_values["simulation_settings"][
-            "path_input_folder"] = path_input_folder
+        dict_values["simulation_settings"]["path_input_folder"] = path_input_folder
 
     # The user specified a value
     if path_output_folder is not None:
-        dict_values["simulation_settings"][
-            "path_output_folder"] = path_output_folder
-        dict_values["simulation_settings"][
-            "path_output_folder_inputs"] = os.path.join(path_output_folder,
-                                                        "inputs")
+        dict_values["simulation_settings"]["path_output_folder"] = path_output_folder
+        dict_values["simulation_settings"]["path_output_folder_inputs"] = os.path.join(
+            path_output_folder, "inputs"
+        )
 
     return dict_values

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -17,20 +17,15 @@ def load_json(
 
     # The user specified a value
     if path_input_folder is not None:
-        if dict_values["simulation_settings"]["path_input_folder"] != path_input_folder:
-            dict_values["simulation_settings"]["path_input_folder"] = path_input_folder
+        dict_values["simulation_settings"][
+            "path_input_folder"] = path_input_folder
 
     # The user specified a value
     if path_output_folder is not None:
-        if (
-            dict_values["simulation_settings"]["path_output_folder"]
-            != path_output_folder
-        ):
-            dict_values["simulation_settings"][
-                "path_output_folder"
-            ] = path_output_folder
-            dict_values["simulation_settings"][
-                "path_output_folder_inputs"
-            ] = os.path.join(path_output_folder, "inputs")
+        dict_values["simulation_settings"][
+            "path_output_folder"] = path_output_folder
+        dict_values["simulation_settings"][
+            "path_output_folder_inputs"] = os.path.join(path_output_folder,
+                                                        "inputs")
 
     return dict_values

--- a/src/D0_modelling_and_optimization.py
+++ b/src/D0_modelling_and_optimization.py
@@ -103,7 +103,7 @@ def run_oemof(dict_values):
     if dict_values["simulation_settings"]["plot_nx_graph"] == True:
         import oemof.graph as grph
 
-        #my_graph = grph.create_nx_graph(model, filename="my_graph.xml")
+        # my_graph = grph.create_nx_graph(model, filename="my_graph.xml")
         from src.F1_plotting import draw_graph
 
         draw_graph(model, node_color={})

--- a/src/D0_modelling_and_optimization.py
+++ b/src/D0_modelling_and_optimization.py
@@ -103,7 +103,7 @@ def run_oemof(dict_values):
     if dict_values["simulation_settings"]["plot_nx_graph"] == True:
         import oemof.graph as grph
 
-        my_graph = grph.create_nx_graph(model, filename="my_graph.xml")
+        #my_graph = grph.create_nx_graph(model, filename="my_graph.xml")
         from src.F1_plotting import draw_graph
 
         draw_graph(model, node_color={})


### PR DESCRIPTION
Deletes lines as agreed on in:
https://github.com/rl-institut/mvs_eland/pull/138

- [x] Describe `kwargs` of `main()` function in docstring and in README (f.e. getting started) (#156)
- [x] Remove deleted parameters from [docs](https://mvs-eland.readthedocs.io/en/latest/MVS_parameters.html) (move to other place)
- [x] Update README (Using the MVS) concerning #135 / PR #138
