### PR TITLE
Update kwargs of main func in docstring and in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Edit the csv files (or, for devs, the json file) and run the `main()` function. 
 - `input_type` (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.
 - `path_input_folder` (str): The path to the directory where the input CSVs/JSON files are located. Default: `inputs/`.
 - `path_output_folder` (str): The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. Default: `MVS_outputs/`.
-
+- `display_output` (str): Sets the level of displayed logging messages. Options: "debug", "info", "warning", "error". Default: "info".
+- `lp_file_output` (bool): Specifies whether linear equation system generated is saved as lp file. Default: False.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ To run the MVS with custom inputs you have several options:
 
 Edit the json input file (or csv files) and run
 
-    `python mvs_tool.py -i path_input_file -ext json -o path_output_folder`
+    `python mvs_tool.py -i path_input_folder -ext json -o path_output_folder`
 
 With 
-`path_input_file`: path to json input file,
+`path_input_folder`: path to folder with input data,
 
 `ext`: json for using a json file and csv for using csv files
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -79,11 +79,11 @@ To run the MVS with custom inputs you have several options:
 
 Edit the json input file (or csv files) and run::
     
-    python mvs_tool.py -i path_input_file -ext json -o path_output_folder
+    python mvs_tool.py -i path_input_folder -ext json -o path_output_folder
     
 With::
     
-    `path_input_file`: path to json input file,
+    `path_input_folder`: path to folder with input files,
     `ext`: json for using a json file and csv for using csv files
     `path_output_folder`: path of the folder where simulation results should be stored.
     

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -99,7 +99,8 @@ Edit the csv files (or, for devs, the json file) and run the `main()` function. 
 - `input_type` (str): Defines whether the input is taken from the `mvs_config.json` file ("json") or from csv files ('csv') located within <path_input_folder>/csv_elements/. Default: `json`.
 - `path_input_folder` (str): The path to the directory where the input CSVs/JSON files are located. Default: `inputs/`.
 - `path_output_folder` (str): The path to the directory where the results of the simulation such as the plots, time series, results JSON files are saved by MVS E-Lands. Default: `MVS_outputs/`.
-
+- `display_output` (str): Sets the level of displayed logging messages. Options: "debug", "info", "warning", "error". Default: "info".
+- `lp_file_output` (bool): Specifies whether linear equation system generated is saved as lp file. Default: False.
 
 Contributing and additional information for developers
 ------------------------------------------------------

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -50,21 +50,27 @@ def main(**kwargs):
 
     Other Parameters
     ----------------
-    overwrite : bool
+    overwrite : bool, optional
         Determines whether to replace existing results in `path_output_folder`
         with the results of the current simulation (True) or not (False).
         Default: False.
-    input_type : str
+    input_type : str, optional
         Defines whether the input is taken from the `mvs_config.json` file
         ("json") or from csv files ('csv') located within
         <path_input_folder>/csv_elements/. Default: 'json'.
-    path_input_folder : str
+    path_input_folder : str, optional
         The path to the directory where the input CSVs/JSON files are located.
         Default: 'inputs/'.
-    path_output_folder : str
+    path_output_folder : str, optional
         The path to the directory where the results of the simulation such as
         the plots, time series, results JSON files are saved by MVS E-Lands.
         Default: 'MVS_outputs/'
+    display_output : str, optional
+        Sets the level of displayed logging messages.
+        Options: "debug", "info", "warning", "error". Default: "info".
+    lp_file_output : bool, optional
+        Specifies whether linear equation system generated is saved as lp file.
+        Default: False.
 
     """
     version = (


### PR DESCRIPTION
Fix #156

Changes proposed in this pull request:
- Add remaining kwargs info to `main()` docstring and documentation


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if tests pass


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
