### PR TITLE
Bug fix TypeError

### DIFF
--- a/inputs/mvs_config.json
+++ b/inputs/mvs_config.json
@@ -679,7 +679,6 @@
         "timestep": {
             "unit": "minutes",
             "value": 60
-        },
-        "plot_nx_graph": "False"
+        }
     }
 }

--- a/src/D0_modelling_and_optimization.py
+++ b/src/D0_modelling_and_optimization.py
@@ -100,7 +100,7 @@ def run_oemof(dict_values):
 
     logging.debug("All components added.")
 
-    if dict_values["simulation_settings"]["plot_nx_graph"]["value"] == True:
+    if dict_values["simulation_settings"]["plot_nx_graph"] == True:
         import oemof.graph as grph
 
         # my_graph = grph.create_nx_graph(model, filename="my_graph.xml")

--- a/src/D0_modelling_and_optimization.py
+++ b/src/D0_modelling_and_optimization.py
@@ -100,7 +100,7 @@ def run_oemof(dict_values):
 
     logging.debug("All components added.")
 
-    if dict_values["simulation_settings"]["plot_nx_graph"] == True:
+    if dict_values["simulation_settings"]["plot_nx_graph"]["value"] == True:
         import oemof.graph as grph
 
         # my_graph = grph.create_nx_graph(model, filename="my_graph.xml")


### PR DESCRIPTION
Fixes 
```
  File "mvs_eland/src/D0_modelling_and_optimization.py", line 103, in run_oemof
    if dict_values["simulation_settings"]["plot_nx_graph"]["value"] == True:
TypeError: string indices must be integers
```
This error occurred with the [example inputs](https://github.com/rl-institut/mvs_eland/tree/dev/inputs) (with json file).