### PR TITLE
plot only if costs_total_rest is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
 - Fix json file (#203)
 - Fix searching for dict key "input_bus_name" (#210) and using input_name instead of output_name (#219)
 - Delete duplicated entry of `plot_nx_graph` from json file (#209)
+- Fix plotting error in F1, plot only if Data frame is not empty (#230, #234)
 
 ## [0.2.0] - 2020-03-13
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -384,7 +384,7 @@ def plot_costs_rest(
         plt.cla()
 
     else:
-        logging.warning("There is no costs_total_rest to plot.")
+        logging.debug("No plot for costs_total_rest created, as remaning costs were 0.")
     return
 
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -357,6 +357,7 @@ def plot_costs_rest(
         {n: costs_total_rest[n] / rest for n in costs_total_rest.keys()}
     )
     costs_total_rest = pd.Series(costs_total_rest)
+    # check if there are any remaining costs that could be plotted
     if costs_total_rest.empty == False:
         costs_total_rest.plot.pie(
             title="Rest of "

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -384,8 +384,9 @@ def plot_costs_rest(
         plt.cla()
 
     else:
-        logging.debug("No plot for costs_total_rest created, as remaining "
-                      "costs were 0.")
+        logging.debug(
+            "No plot for costs_total_rest created, as remaining costs were 0."
+        )
     return
 
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -384,8 +384,8 @@ def plot_costs_rest(
         plt.cla()
 
     else:
-        logging.debug("No plot for costs_total_rest created, as remaning costs"
-                      " were 0.")
+        logging.debug("No plot for costs_total_rest created, as remaining "
+                      "costs were 0.")
     return
 
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -384,7 +384,8 @@ def plot_costs_rest(
         plt.cla()
 
     else:
-        logging.debug("No plot for costs_total_rest created, as remaning costs were 0.")
+        logging.debug("No plot for costs_total_rest created, as remaning costs"
+                      " were 0.")
     return
 
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -357,30 +357,33 @@ def plot_costs_rest(
         {n: costs_total_rest[n] / rest for n in costs_total_rest.keys()}
     )
     costs_total_rest = pd.Series(costs_total_rest)
-    costs_total_rest.plot.pie(
-        title="Rest of "
-        + label
-        + "("
-        + str(round((1 - major_value) * 100))
-        + "% of "
-        + str(round(total, 2))
-        + "$): "
-        + project_data["project_name"]
-        + ", "
-        + project_data["scenario_name"],
-        autopct="%1.1f%%",
-        subplots=True,
-    )
+    if costs_total_rest.empty == False:
+        costs_total_rest.plot.pie(
+            title="Rest of "
+            + label
+            + "("
+            + str(round((1 - major_value) * 100))
+            + "% of "
+            + str(round(total, 2))
+            + "$): "
+            + project_data["project_name"]
+            + ", "
+            + project_data["scenario_name"],
+            autopct="%1.1f%%",
+            subplots=True,
+        )
 
-    plt.savefig(
-        settings["path_output_folder"] + "/" + path + "_other_costs.png",
-        bbox_inches="tight",
-    )
+        plt.savefig(
+            settings["path_output_folder"] + "/" + path + "_other_costs.png",
+            bbox_inches="tight",
+        )
 
-    plt.close()
-    plt.clf()
-    plt.cla()
+        plt.close()
+        plt.clf()
+        plt.cla()
 
+    else:
+        logging.warning("There is no costs_total_rest to plot.")
     return
 
 


### PR DESCRIPTION
Fix #234 #230 

So in my case there was simply no cost_total_rest, so it turned out to be an empty dataframe that cannot be plotted. I solved it by simply adding an if statement that only plots the dataframe if it's not empty. If it's empty there's a warning. Please feel free to edit the warning message.

**Changes proposed in this pull request**:
- Your_changes

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if tests pass


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
