### PR TITLE
Feature/optinal max cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Here is a template for new release sections
 - Readthedocs documentation for installation (#162)
 - Plotting an networkx graph can now be turned of/on via "plot_nx_graph" in simulation_settings (#172)
 - Plot all timeseries used as input data (#171)
+- Integrate new parameter maximumCap as nominal value for powerplants (#124)
 
 ### Changed
 - Give priority from kwargs on command line arguments (#112, #138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Here is a template for new release sections
 - Readthedocs documentation for installation (#162)
 - Plotting an networkx graph can now be turned of/on via "plot_nx_graph" in simulation_settings (#172)
 - Plot all timeseries used as input data (#171)
-- Integrate new parameter maximumCap as nominal value for powerplants (#124)
+- Integrate new parameter maximumCap as nominal value for energyProduction assets, ie. PV or wind plants (#124)
 
 ### Changed
 - Give priority from kwargs on command line arguments (#112, #138)
@@ -158,4 +158,3 @@ Here is a template for new release sections
 
 ### Removed
 - yet another thing
-

--- a/inputs/csv_elements/energyProduction.csv
+++ b/inputs/csv_elements/energyProduction.csv
@@ -3,7 +3,8 @@ age_installed,year,0
 capex_fix,currency,10000
 capex_var,currency/unit,7200
 file_name,str,pv_gen_merra2_2014_eff1_tilt40_az180.csv
-installedCap,kWp,0
+installedCap,kWp,500
+maximumCap, kWp, 1000
 label,str,PV plant (mono)
 lifetime,year,30
 opex_fix,currency/unit/year,80

--- a/inputs/csv_elements/energyProduction.csv
+++ b/inputs/csv_elements/energyProduction.csv
@@ -3,7 +3,7 @@ age_installed,year,0
 capex_fix,currency,10000
 capex_var,currency/unit,7200
 file_name,str,pv_gen_merra2_2014_eff1_tilt40_az180.csv
-installedCap,kWp,500
+installedCap,kWp,1500
 maximumCap, kWp, 1000
 label,str,PV plant (mono)
 lifetime,year,30

--- a/inputs/mvs_config.json
+++ b/inputs/mvs_config.json
@@ -333,6 +333,10 @@
                 "unit": "kWp",
                 "value": 0
             },
+            "maximumCap": {
+                "unit": "kWp",
+                "value": 1000
+            },
             "label": "PV plant (mono)",
             "lifetime": {
                 "unit": "year",

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -303,8 +303,11 @@ def create_json_from_csv(input_directory, filename, parameters):
     )
 
     # check wether parameter maximumCap is availavle                             #todo in next version: add maximumCap to hardcoded parameter list above
-    if "maximumCap" in df.index:
-        parameters.append("maximumCap")
+   new_parameter = "maximumCap"
+    if new_parameter  in df.index:
+        parameters.append(new_parameter )
+   else:
+       logging.warning("You are not using the parameter %s for asset group %s, which allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). In the upcoming version of the MVS, this parameter will be required.", new_parameter, filename) 
 
     # check parameters
     extra = list(set(parameters) ^ set(df.index))

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -302,7 +302,7 @@ def create_json_from_csv(input_directory, filename, parameters):
         index_col=0,
     )
 
-    #check wether parameter maximumCap is availavle                             #todo in next version: add maximumCap to hardcoded parameter list above
+    # check wether parameter maximumCap is availavle                             #todo in next version: add maximumCap to hardcoded parameter list above
     if "maximumCap" in df.index:
         parameters.append("maximumCap")
 

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -131,6 +131,7 @@ def create_input_json(
                 "capex_var",
                 "file_name",
                 "installedCap",
+                "maximumCap",
                 "label",
                 "lifetime",
                 "opex_fix",

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -303,11 +303,15 @@ def create_json_from_csv(input_directory, filename, parameters):
     )
 
     # check wether parameter maximumCap is availavle                             #todo in next version: add maximumCap to hardcoded parameter list above
-   new_parameter = "maximumCap"
-    if new_parameter  in df.index:
-        parameters.append(new_parameter )
-   else:
-       logging.warning("You are not using the parameter %s for asset group %s, which allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). In the upcoming version of the MVS, this parameter will be required.", new_parameter, filename) 
+    new_parameter = "maximumCap"
+    if new_parameter in df.index:
+        parameters.append(new_parameter)
+    else:
+        logging.warning(
+            "You are not using the parameter %s for asset group %s, which allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). In the upcoming version of the MVS, this parameter will be required.",
+            new_parameter,
+            filename,
+        )
 
     # check parameters
     extra = list(set(parameters) ^ set(df.index))

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -131,7 +131,6 @@ def create_input_json(
                 "capex_var",
                 "file_name",
                 "installedCap",
-                "maximumCap",
                 "label",
                 "lifetime",
                 "opex_fix",
@@ -302,6 +301,10 @@ def create_json_from_csv(input_directory, filename, parameters):
         header=0,
         index_col=0,
     )
+
+    #check wether parameter maximumCap is availavle                             #todo in next version: add maximumCap to hardcoded parameter list above
+    if "maximumCap" in df.index:
+        parameters.append("maximumCap")
 
     # check parameters
     extra = list(set(parameters) ^ set(df.index))

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -257,6 +257,15 @@ def energyProduction(dict_values, group):
             receive_timeseries_from_csv(
                 dict_values["simulation_settings"], dict_values[group][asset], "input",
             )
+        if "maximumCap" in dict_values[group][asset]:
+            # check if maximumCap is greater that installedCap
+            if dict_values[group][asset]["maximumCap"]["value"] < \
+                    dict_values[group][asset]["installedCap"]["value"]:
+                logging.warning("The stated maximumCap is smaller than the "
+                              "installedCap. Please enter a greater maximumCap"
+                              ". This way the maximumCap will not be used in "
+                              "the simulation")
+                del dict_values[group][asset]["maximumCap"]
     return
 
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -259,6 +259,7 @@ def energyProduction(dict_values, group):
             )
         if "maximumCap" in dict_values[group][asset]:
             # check if maximumCap is greater that installedCap
+
             if dict_values[group][asset]["maximumCap"]["value"] is not None:
                 if (
                     dict_values[group][asset]["maximumCap"]["value"]
@@ -267,9 +268,9 @@ def energyProduction(dict_values, group):
 
                     logging.warning(
                         "The stated maximumCap is smaller than the "
-                        "installedCap. Please enter a greater maximumCap"
-                        ". This way the maximumCap will not be used in "
-                        "the simulation"
+                        "installedCap. Please enter a greater maximumCap."
+                        "For this simulation, the maximumCap will be "
+                        "disregarded and not be used in the simulation"
                     )
                     dict_values[group][asset]["maximumCap"] = None
                 # check if maximumCao is 0

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -259,12 +259,16 @@ def energyProduction(dict_values, group):
             )
         if "maximumCap" in dict_values[group][asset]:
             # check if maximumCap is greater that installedCap
-            if dict_values[group][asset]["maximumCap"]["value"] < \
-                    dict_values[group][asset]["installedCap"]["value"]:
-                logging.warning("The stated maximumCap is smaller than the "
-                              "installedCap. Please enter a greater maximumCap"
-                              ". This way the maximumCap will not be used in "
-                              "the simulation")
+            if (
+                dict_values[group][asset]["maximumCap"]["value"]
+                < dict_values[group][asset]["installedCap"]["value"]
+            ):
+                logging.warning(
+                    "The stated maximumCap is smaller than the "
+                    "installedCap. Please enter a greater maximumCap"
+                    ". This way the maximumCap will not be used in "
+                    "the simulation"
+                )
                 del dict_values[group][asset]["maximumCap"]
     return
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -699,7 +699,7 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
 
-    #check if maximumCap exists in energyProduction dict and add it to source
+    # check if maximumCap exists in energyProduction dict and add it to source
     if "maximumCap" in set().union(
         *dict_values["energyProduction"].values()
     ):  # todo: make this more generic also for energyCoversion??
@@ -708,17 +708,27 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
         for key in set().union(dict_values["energyProduction"].keys()):
             # check if installedCap exists in the dict
             if "installedCap" in dict_values["energyProduction"][key]:
-                #check if maximumCap >= installedCap
-                if (dict_values["energyProduction"][key]["maximumCap"]["value"] >= dict_values["energyProduction"][key]["installedCap"]["value"]):
-                    #add maximumCap to source
+                # check if maximumCap >= installedCap
+                if (
+                    dict_values["energyProduction"][key]["maximumCap"]["value"]
+                    >= dict_values["energyProduction"][key]["installedCap"]
+                ["value"]
+                ):
+                    # add maximumCap to source
                     source.update(
-                        {"maximumCap": dict_values["energyProduction"][key]
-                        ["maximumCap"]})
+                        {
+                            "maximumCap": dict_values["energyProduction"][key][
+                                "maximumCap"
+                            ]
+                        }
+                    )
                 else:
-                    logging.warning("The stated maximumCap is smaller than the"
-                              " installedCap. Please enter a greater "
-                              "maximumCap. This way the maximumCap will not be "
-                              "used in the simulation.")
+                    logging.warning(
+                        "The stated maximumCap is smaller than the"
+                        " installedCap. Please enter a greater "
+                        "maximumCap. This way the maximumCap will not be "
+                        "used in the simulation."
+                    )
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -259,17 +259,27 @@ def energyProduction(dict_values, group):
             )
         if "maximumCap" in dict_values[group][asset]:
             # check if maximumCap is greater that installedCap
-            if (
-                dict_values[group][asset]["maximumCap"]["value"]
-                < dict_values[group][asset]["installedCap"]["value"]
-            ):
-                logging.warning(
-                    "The stated maximumCap is smaller than the "
-                    "installedCap. Please enter a greater maximumCap"
-                    ". This way the maximumCap will not be used in "
-                    "the simulation"
-                )
-                del dict_values[group][asset]["maximumCap"]
+            if dict_values[group][asset]["maximumCap"]["value"] is not None:
+                if (
+                    dict_values[group][asset]["maximumCap"]["value"]
+                    < dict_values[group][asset]["installedCap"]["value"]
+                ):
+
+                    logging.warning(
+                        "The stated maximumCap is smaller than the "
+                        "installedCap. Please enter a greater maximumCap"
+                        ". This way the maximumCap will not be used in "
+                        "the simulation"
+                    )
+                    dict_values[group][asset]["maximumCap"] = None
+                # check if maximumCao is 0
+                elif dict_values[group][asset]["maximumCap"]["value"] == 0:
+                    logging.warning(
+                        "The stated maximumCap of zero is invalid."
+                        "For this simulation, the maximumCap will be "
+                        "disregarded and not be used in the simulation."
+                    )
+                    dict_values[group][asset]["maximumCap"] = None
     return
 
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -698,6 +698,9 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
             )
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
+    if "maximumCap" in dict_values["energyProduction"]["pv_plant_01"]:          #todo: correct pvplant
+        source.update({"maximumCap": dict_values["energyProduction"]
+        ["pv_plant_01"]["maximumCap"]})
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -700,10 +700,13 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
 
     # check if maximumCap exists in energyProduction dict and add it to source
-    if "maximumCap" in set().union(*dict_values["energyProduction"].values()): #todo: make this more generic also for energyCoversion??
+    if "maximumCap" in set().union(
+        *dict_values["energyProduction"].values()
+    ):  # todo: make this more generic also for energyCoversion??
         for key in set().union(dict_values["energyProduction"].keys()):
-            source.update({"maximumCap": dict_values["energyProduction"]
-            [key]["maximumCap"]})
+            source.update(
+                {"maximumCap": dict_values["energyProduction"][key]["maximumCap"]}
+            )
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -698,9 +698,10 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
             )
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
-    if "maximumCap" in dict_values["energyProduction"]["pv_plant_01"]:          #todo: correct pvplant
-        source.update({"maximumCap": dict_values["energyProduction"]
-        ["pv_plant_01"]["maximumCap"]})
+    if "maximumCap" in set().union(*dict_values["energyProduction"].values()): #todo: make this more generic also for energyCoversion??
+        for key in set().union(dict_values["energyProduction"].keys()):
+            source.update({"maximumCap": dict_values["energyProduction"]
+            [key]["maximumCap"]})
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -698,6 +698,8 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
             )
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
+
+    # check if maximumCap exists in energyProduction dict and add it to source
     if "maximumCap" in set().union(*dict_values["energyProduction"].values()): #todo: make this more generic also for energyCoversion??
         for key in set().union(dict_values["energyProduction"].keys()):
             source.update({"maximumCap": dict_values["energyProduction"]

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -699,36 +699,6 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
 
-    # check if maximumCap exists in energyProduction dict and add it to source
-    if "maximumCap" in set().union(
-        *dict_values["energyProduction"].values()
-    ):  # todo: make this more generic also for energyCoversion??
-        # todo: maybe this section can be written nicer
-
-        for key in set().union(dict_values["energyProduction"].keys()):
-            # check if installedCap exists in the dict
-            if "installedCap" in dict_values["energyProduction"][key]:
-                # check if maximumCap >= installedCap
-                if (
-                    dict_values["energyProduction"][key]["maximumCap"]["value"]
-                    >= dict_values["energyProduction"][key]["installedCap"]["value"]
-                ):
-                    # add maximumCap to source
-                    source.update(
-                        {
-                            "maximumCap": dict_values["energyProduction"][key][
-                                "maximumCap"
-                            ]
-                        }
-                    )
-                else:
-                    logging.warning(
-                        "The stated maximumCap is smaller than the"
-                        " installedCap. Please enter a greater "
-                        "maximumCap. This way the maximumCap will not be "
-                        "used in the simulation."
-                    )
-
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -703,10 +703,19 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
     if "maximumCap" in set().union(
         *dict_values["energyProduction"].values()
     ):  # todo: make this more generic also for energyCoversion??
+
         for key in set().union(dict_values["energyProduction"].keys()):
-            source.update(
-                {"maximumCap": dict_values["energyProduction"][key]["maximumCap"]}
-            )
+            # check if maximumCap is greater that installedCap
+            if dict_values["energyProduction"][key]["maximumCap"]["value"] >= \
+                dict_values["energyProduction"][key]["installedCap"]["value"]:
+                source.update(
+                    {"maximumCap": dict_values["energyProduction"][key]["maximumCap"]}
+                )
+            else:
+                logging.warning("The stated maximumCap is smaller than the "
+                              "installedCap. Please enter a greater maximumCap"
+                              ". This way the maximumCap will not be used in "
+                              "the simulation")
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -699,23 +699,26 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
     else:
         source.update({"optimizeCap": {"value": False, "unit": "bool"}})
 
-    # check if maximumCap exists in energyProduction dict and add it to source
+    #check if maximumCap exists in energyProduction dict and add it to source
     if "maximumCap" in set().union(
         *dict_values["energyProduction"].values()
     ):  # todo: make this more generic also for energyCoversion??
+        # todo: maybe this section can be written nicer
 
         for key in set().union(dict_values["energyProduction"].keys()):
-            # check if maximumCap is greater that installedCap
-            if dict_values["energyProduction"][key]["maximumCap"]["value"] >= \
-                dict_values["energyProduction"][key]["installedCap"]["value"]:
-                source.update(
-                    {"maximumCap": dict_values["energyProduction"][key]["maximumCap"]}
-                )
-            else:
-                logging.warning("The stated maximumCap is smaller than the "
-                              "installedCap. Please enter a greater maximumCap"
-                              ". This way the maximumCap will not be used in "
-                              "the simulation")
+            # check if installedCap exists in the dict
+            if "installedCap" in dict_values["energyProduction"][key]:
+                #check if maximumCap >= installedCap
+                if (dict_values["energyProduction"][key]["maximumCap"]["value"] >= dict_values["energyProduction"][key]["installedCap"]["value"]):
+                    #add maximumCap to source
+                    source.update(
+                        {"maximumCap": dict_values["energyProduction"][key]
+                        ["maximumCap"]})
+                else:
+                    logging.warning("The stated maximumCap is smaller than the"
+                              " installedCap. Please enter a greater "
+                              "maximumCap. This way the maximumCap will not be "
+                              "used in the simulation.")
 
     # update dictionary
     dict_values["energyProduction"].update({asset_name: source})

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -711,8 +711,7 @@ def define_source(dict_values, asset_name, price, output_bus, timeseries, **kwar
                 # check if maximumCap >= installedCap
                 if (
                     dict_values["energyProduction"][key]["maximumCap"]["value"]
-                    >= dict_values["energyProduction"][key]["installedCap"]
-                ["value"]
+                    >= dict_values["energyProduction"][key]["installedCap"]["value"]
                 ):
                     # add maximumCap to source
                     source.update(

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -271,7 +271,7 @@ def energyProduction(dict_values, group):
                         "For this simulation, the maximumCap will be "
                         "disregarded and not be used in the simulation"
                     )
-                    dict_values[group][asset]["maximumCap"] = None
+                    dict_values[group][asset]["maximumCap"]["value"] = None
                 # check if maximumCao is 0
                 elif dict_values[group][asset]["maximumCap"]["value"] == 0:
                     logging.warning(
@@ -279,18 +279,7 @@ def energyProduction(dict_values, group):
                         "For this simulation, the maximumCap will be "
                         "disregarded and not be used in the simulation."
                     )
-                    dict_values[group][asset]["maximumCap"] = None
-            if (
-                dict_values[group][asset]["maximumCap"]["value"]
-                < dict_values[group][asset]["installedCap"]["value"]
-            ):
-                logging.warning(
-                    "The stated maximumCap is smaller than the "
-                    "installedCap. Please enter a greater maximumCap"
-                    ". For this simulation, the maximumCap will be disregarded and not be used in "
-                    "the simulation."
-                )
-                del dict_values[group][asset]["maximumCap"]
+                    dict_values[group][asset]["maximumCap"]["value"] = None
     return
 
 

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -112,6 +112,7 @@ def all_valid_intervals(name, value, title):
         "lifetime": ["largerzero", "any"],
         "age_installed": [0, "any"],
         "installedCap": [0, "any"],
+        "maximumCap" : [0, "any"],
         "soc_min": [0, 1],
         "soc_max": [0, 1],
         "soc_initial": [0, 1],

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -112,7 +112,7 @@ def all_valid_intervals(name, value, title):
         "lifetime": ["largerzero", "any"],
         "age_installed": [0, "any"],
         "installedCap": [0, "any"],
-        "maximumCap" : [0, "any"],
+        "maximumCap": [0, "any"],
         "soc_min": [0, 1],
         "soc_max": [0, 1],
         "soc_initial": [0, 1],

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -112,7 +112,7 @@ def all_valid_intervals(name, value, title):
         "lifetime": ["largerzero", "any"],
         "age_installed": [0, "any"],
         "installedCap": [0, "any"],
-        "maximumCap": [0, "any"],
+        "maximumCap": [0, "any", None],
         "soc_min": [0, 1],
         "soc_max": [0, 1],
         "soc_initial": [0, 1],

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -449,7 +449,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum = dict_asset["maximumCap"]
+                            maximum = dict_asset["maximumCap"]["value"]
                         ),
                         variable_costs=dict_asset["opex_var"]["value"][0]
                         / dict_asset["timeseries_peak"]["value"],
@@ -477,7 +477,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]
+                            maximum=dict_asset["maximumCap"]["value"]
                         ),
                         variable_costs=dict_asset["opex_var"]["value"]
                         / dict_asset["timeseries_peak"]["value"]

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -409,11 +409,11 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
                     existing=dict_asset["installedCap"]["value"],
                     investment=solph.Investment(
                         ep_costs=dict_asset["simulation_annuity"]["value"]
-                                 / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]["value"]
+                        / dict_asset["timeseries_peak"]["value"],
+                        maximum=dict_asset["maximumCap"]["value"],
                     ),
                     variable_costs=dict_asset["opex_var"]["value"][index]
-                                   / dict_asset["timeseries_peak"]["value"],
+                    / dict_asset["timeseries_peak"]["value"],
                 )
             else:
                 outputs[kwargs["busses"][bus]] = solph.Flow(
@@ -423,10 +423,10 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
                     existing=dict_asset["installedCap"]["value"],
                     investment=solph.Investment(
                         ep_costs=dict_asset["simulation_annuity"]["value"]
-                                 / dict_asset["timeseries_peak"]["value"]
+                        / dict_asset["timeseries_peak"]["value"]
                     ),
                     variable_costs=dict_asset["opex_var"]["value"][index]
-                                   / dict_asset["timeseries_peak"]["value"],
+                    / dict_asset["timeseries_peak"]["value"],
                 )
                 index += 1
 
@@ -441,12 +441,12 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
                     investment=solph.Investment(
                         ep_costs=dict_asset["simulation_annuity"]["value"]
                         / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]["value"]
+                        maximum=dict_asset["maximumCap"]["value"],
                     ),
                     variable_costs=dict_asset["opex_var"]["value"]
                     / dict_asset["timeseries_peak"]["value"],
                 )
-             }
+            }
         else:
             outputs = {
                 kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
@@ -456,10 +456,10 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
                     existing=dict_asset["installedCap"]["value"],
                     investment=solph.Investment(
                         ep_costs=dict_asset["simulation_annuity"]["value"]
-                                 / dict_asset["timeseries_peak"]["value"]
+                        / dict_asset["timeseries_peak"]["value"]
                     ),
                     variable_costs=dict_asset["opex_var"]["value"]
-                                   / dict_asset["timeseries_peak"]["value"],
+                    / dict_asset["timeseries_peak"]["value"],
                 )
             }
 
@@ -486,7 +486,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]["value"]
+                            maximum=dict_asset["maximumCap"]["value"],
                         ),
                         variable_costs=dict_asset["opex_var"]["value"][0]
                         / dict_asset["timeseries_peak"]["value"],

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -442,6 +442,8 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
             outputs = {}
             index = 0
             for bus in dict_asset["output_bus_name"]:
+                # check if maximumCap parameter exists, if it is greater than 0
+                # and add it to solph.Flow()
                 if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
                     outputs[kwargs["busses"][bus]] = solph.Flow(
                         label=dict_asset["label"],
@@ -469,6 +471,8 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
 
                 index += 1
         else:
+            #check if maximumCap parameter exists, if it is greater than 0
+            # and add it to solph.Flow()
             if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
                 outputs = {
                     kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -399,9 +399,9 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
         outputs = {}
         index = 0
         for bus in dict_asset["output_bus_name"]:
-            # check if maximumCap parameter exists, if it is greater than 0
+            # check if maximumCap parameter exists
             # and add it to solph.Flow()
-            if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+            if "maximumCap" in dict_asset:
                 outputs[kwargs["busses"][bus]] = solph.Flow(
                     label=dict_asset["label"],
                     actual_value=dict_asset["timeseries_normalized"],
@@ -431,7 +431,7 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
                 index += 1
 
     else:
-        if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+        if "maximumCap" in dict_asset:
             outputs = {
                 kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
                     label=dict_asset["label"],
@@ -477,9 +477,9 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
             outputs = {}
             index = 0
             for bus in dict_asset["output_bus_name"]:
-                # check if maximumCap parameter exists, if it is greater than 0
+                # check if maximumCap parameter exists
                 # and add it to solph.Flow()
-                if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+                if "maximumCap" in dict_asset:
                     outputs[kwargs["busses"][bus]] = solph.Flow(
                         label=dict_asset["label"],
                         max=dict_asset["timeseries_normalized"],
@@ -505,9 +505,9 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
 
                 index += 1
         else:
-            # check if maximumCap parameter exists, if it is greater than 0
+            # check if maximumCap parameter exists
             # and add it to solph.Flow()
-            if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+            if "maximumCap" in dict_asset:
                 outputs = {
                     kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
                         label=dict_asset["label"],

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -451,7 +451,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum = dict_asset["maximumCap"]["value"]
+                            maximum=dict_asset["maximumCap"]["value"],
                         ),
                         variable_costs=dict_asset["opex_var"]["value"][0]
                         / dict_asset["timeseries_peak"]["value"],
@@ -462,16 +462,15 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         max=dict_asset["timeseries_normalized"],
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
-                                     / dict_asset["timeseries_peak"]["value"]
+                            / dict_asset["timeseries_peak"]["value"]
                         ),
                         variable_costs=dict_asset["opex_var"]["value"][0]
-                                       / dict_asset["timeseries_peak"][
-                                           "value"]
+                        / dict_asset["timeseries_peak"]["value"],
                     )
 
                 index += 1
         else:
-            #check if maximumCap parameter exists, if it is greater than 0
+            # check if maximumCap parameter exists, if it is greater than 0
             # and add it to solph.Flow()
             if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
                 outputs = {
@@ -481,24 +480,23 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]["value"]
+                            maximum=dict_asset["maximumCap"]["value"],
                         ),
                         variable_costs=dict_asset["opex_var"]["value"]
-                        / dict_asset["timeseries_peak"]["value"]
+                        / dict_asset["timeseries_peak"]["value"],
                     )
                 }
             else:
                 outputs = {
-                    kwargs["busses"][
-                        dict_asset["output_bus_name"]]: solph.Flow(
+                    kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
                         label=dict_asset["label"],
                         max=dict_asset["timeseries_normalized"],
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
-                                     / dict_asset["timeseries_peak"]["value"]
+                            / dict_asset["timeseries_peak"]["value"]
                         ),
                         variable_costs=dict_asset["opex_var"]["value"]
-                                       / dict_asset["timeseries_peak"]["value"]
+                        / dict_asset["timeseries_peak"]["value"],
                     )
                 }
 

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -442,30 +442,61 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
             outputs = {}
             index = 0
             for bus in dict_asset["output_bus_name"]:
-                outputs[kwargs["busses"][bus]] = solph.Flow(
-                    label=dict_asset["label"],
-                    max=dict_asset["timeseries_normalized"],
-                    investment=solph.Investment(
-                        ep_costs=dict_asset["simulation_annuity"]["value"]
-                        / dict_asset["timeseries_peak"]["value"]
-                    ),
-                    variable_costs=dict_asset["opex_var"]["value"][0]
-                    / dict_asset["timeseries_peak"]["value"],
-                )
+                if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+                    outputs[kwargs["busses"][bus]] = solph.Flow(
+                        label=dict_asset["label"],
+                        max=dict_asset["timeseries_normalized"],
+                        investment=solph.Investment(
+                            ep_costs=dict_asset["simulation_annuity"]["value"]
+                            / dict_asset["timeseries_peak"]["value"],
+                            maximum = dict_asset["maximumCap"]
+                        ),
+                        variable_costs=dict_asset["opex_var"]["value"][0]
+                        / dict_asset["timeseries_peak"]["value"],
+                    )
+                else:
+                    outputs[kwargs["busses"][bus]] = solph.Flow(
+                        label=dict_asset["label"],
+                        max=dict_asset["timeseries_normalized"],
+                        investment=solph.Investment(
+                            ep_costs=dict_asset["simulation_annuity"]["value"]
+                                     / dict_asset["timeseries_peak"]["value"]
+                        ),
+                        variable_costs=dict_asset["opex_var"]["value"][0]
+                                       / dict_asset["timeseries_peak"][
+                                           "value"]
+                    )
+
                 index += 1
         else:
-            outputs = {
-                kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
-                    label=dict_asset["label"],
-                    max=dict_asset["timeseries_normalized"],
-                    investment=solph.Investment(
-                        ep_costs=dict_asset["simulation_annuity"]["value"]
+            if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+                outputs = {
+                    kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
+                        label=dict_asset["label"],
+                        max=dict_asset["timeseries_normalized"],
+                        investment=solph.Investment(
+                            ep_costs=dict_asset["simulation_annuity"]["value"]
+                            / dict_asset["timeseries_peak"]["value"],
+                            maximum=dict_asset["maximumCap"]
+                        ),
+                        variable_costs=dict_asset["opex_var"]["value"]
                         / dict_asset["timeseries_peak"]["value"]
-                    ),
-                    variable_costs=dict_asset["opex_var"]["value"]
-                    / dict_asset["timeseries_peak"]["value"],
-                )
-            }
+                    )
+                }
+            else:
+                outputs = {
+                    kwargs["busses"][
+                        dict_asset["output_bus_name"]]: solph.Flow(
+                        label=dict_asset["label"],
+                        max=dict_asset["timeseries_normalized"],
+                        investment=solph.Investment(
+                            ep_costs=dict_asset["simulation_annuity"]["value"]
+                                     / dict_asset["timeseries_peak"]["value"]
+                        ),
+                        variable_costs=dict_asset["opex_var"]["value"]
+                                       / dict_asset["timeseries_peak"]["value"]
+                    )
+                }
 
         source_dispatchable = solph.Source(label=dict_asset["label"], outputs=outputs,)
     else:

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -399,34 +399,69 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
         outputs = {}
         index = 0
         for bus in dict_asset["output_bus_name"]:
-            outputs[kwargs["busses"][bus]] = solph.Flow(
-                label=dict_asset["label"],
-                actual_value=dict_asset["timeseries_normalized"],
-                fixed=True,
-                existing=dict_asset["installedCap"]["value"],
-                investment=solph.Investment(
-                    ep_costs=dict_asset["simulation_annuity"]["value"]
-                    / dict_asset["timeseries_peak"]["value"]
-                ),
-                variable_costs=dict_asset["opex_var"]["value"][index]
-                / dict_asset["timeseries_peak"]["value"],
-            )
-            index += 1
+            # check if maximumCap parameter exists, if it is greater than 0
+            # and add it to solph.Flow()
+            if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+                outputs[kwargs["busses"][bus]] = solph.Flow(
+                    label=dict_asset["label"],
+                    actual_value=dict_asset["timeseries_normalized"],
+                    fixed=True,
+                    existing=dict_asset["installedCap"]["value"],
+                    investment=solph.Investment(
+                        ep_costs=dict_asset["simulation_annuity"]["value"]
+                                 / dict_asset["timeseries_peak"]["value"],
+                            maximum=dict_asset["maximumCap"]["value"]
+                    ),
+                    variable_costs=dict_asset["opex_var"]["value"][index]
+                                   / dict_asset["timeseries_peak"]["value"],
+                )
+            else:
+                outputs[kwargs["busses"][bus]] = solph.Flow(
+                    label=dict_asset["label"],
+                    actual_value=dict_asset["timeseries_normalized"],
+                    fixed=True,
+                    existing=dict_asset["installedCap"]["value"],
+                    investment=solph.Investment(
+                        ep_costs=dict_asset["simulation_annuity"]["value"]
+                                 / dict_asset["timeseries_peak"]["value"]
+                    ),
+                    variable_costs=dict_asset["opex_var"]["value"][index]
+                                   / dict_asset["timeseries_peak"]["value"],
+                )
+                index += 1
+
     else:
-        outputs = {
-            kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
-                label=dict_asset["label"],
-                actual_value=dict_asset["timeseries_normalized"],
-                fixed=True,
-                existing=dict_asset["installedCap"]["value"],
-                investment=solph.Investment(
-                    ep_costs=dict_asset["simulation_annuity"]["value"]
-                    / dict_asset["timeseries_peak"]["value"]
-                ),
-                variable_costs=dict_asset["opex_var"]["value"]
-                / dict_asset["timeseries_peak"]["value"],
-            )
-        }
+        if "maximumCap" in dict_asset and dict_asset["maximumCap"]["value"] > 0:
+            outputs = {
+                kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
+                    label=dict_asset["label"],
+                    actual_value=dict_asset["timeseries_normalized"],
+                    fixed=True,
+                    existing=dict_asset["installedCap"]["value"],
+                    investment=solph.Investment(
+                        ep_costs=dict_asset["simulation_annuity"]["value"]
+                        / dict_asset["timeseries_peak"]["value"],
+                            maximum=dict_asset["maximumCap"]["value"]
+                    ),
+                    variable_costs=dict_asset["opex_var"]["value"]
+                    / dict_asset["timeseries_peak"]["value"],
+                )
+             }
+        else:
+            outputs = {
+                kwargs["busses"][dict_asset["output_bus_name"]]: solph.Flow(
+                    label=dict_asset["label"],
+                    actual_value=dict_asset["timeseries_normalized"],
+                    fixed=True,
+                    existing=dict_asset["installedCap"]["value"],
+                    investment=solph.Investment(
+                        ep_costs=dict_asset["simulation_annuity"]["value"]
+                                 / dict_asset["timeseries_peak"]["value"]
+                    ),
+                    variable_costs=dict_asset["opex_var"]["value"]
+                                   / dict_asset["timeseries_peak"]["value"],
+                )
+            }
 
     source_non_dispatchable = solph.Source(label=dict_asset["label"], outputs=outputs)
 
@@ -451,7 +486,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
                         investment=solph.Investment(
                             ep_costs=dict_asset["simulation_annuity"]["value"]
                             / dict_asset["timeseries_peak"]["value"],
-                            maximum=dict_asset["maximumCap"]["value"],
+                            maximum=dict_asset["maximumCap"]["value"]
                         ),
                         variable_costs=dict_asset["opex_var"]["value"][0]
                         / dict_asset["timeseries_peak"]["value"],


### PR DESCRIPTION
Fix #125 

**Changes proposed in this pull request**:
- a new optinal (!) parameter maximumCap is introduced in energyProduction.csv that functions as a maximum nominal value for the optimized installed capacity

**Open Questions**:
right now the maximumCap value is only added if it occurs in "energyProduction". It could easily be extended to "energyConversion" by adapting the section in C0. Would that be beneficial?

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if tests pass


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
