### PR TITLE
add new storage parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Here is a template for new release sections
 - Fix searching for dict key "input_bus_name" (#210) and using input_name instead of output_name (#219)
 - Delete duplicated entry of `plot_nx_graph` from json file (#209)
 - Fix plotting error in F1, plot only if Data frame is not empty (#230, #234)
+- Fix naming error for storages (#166)
 
 ## [0.2.0] - 2020-03-13
 

--- a/inputs/csv_elements/energyStorage.csv
+++ b/inputs/csv_elements/energyStorage.csv
@@ -4,5 +4,5 @@ label,str,ESS Li-Ion
 optimizeCap,bool,True
 outflow_direction,str,ESS Li-Ion
 type_oemof,str,storage
-storage_filename,str,storage01.csv
+storage_filename,str,storage_01.csv
 energyVector,str,Electricity

--- a/inputs/mvs_config.json
+++ b/inputs/mvs_config.json
@@ -550,7 +550,7 @@
                 "value": true
             },
             "outflow_direction": "ESS Li-Ion",
-            "storage_filename": "storage01.csv",
+            "storage_filename": "storage_01.csv",
             "type_oemof": "storage"
         }
     },

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -269,8 +269,7 @@ def create_input_json(
         return outfile.name
 
 
-def create_json_from_csv(input_directory, filename, parameters,
-                         storage = False):
+def create_json_from_csv(input_directory, filename, parameters, storage=False):
 
     """
     One csv file is loaded and it's parameters are checked. The csv file is
@@ -394,8 +393,9 @@ def create_json_from_csv(input_directory, filename, parameters,
             single_dict.update({column: column_dict})
             # add exception for energyStorage
             if filename == "energyStorage":
-                storage_dict = add_storage(df.loc["storage_filename"][column][:-4],
-                                           input_directory)
+                storage_dict = add_storage(
+                    df.loc["storage_filename"][column][:-4], input_directory
+                )
                 single_dict[column].update(storage_dict)
 
     logging.info(
@@ -500,7 +500,9 @@ def add_storage(storage_filename, input_directory):
             "unit",
         ]
         single_dict = create_json_from_csv(
-            input_directory, filename=storage_filename, parameters=parameters,
-            storage=True
+            input_directory,
+            filename=storage_filename,
+            parameters=parameters,
+            storage=True,
         )
         return single_dict

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -269,7 +269,8 @@ def create_input_json(
         return outfile.name
 
 
-def create_json_from_csv(input_directory, filename, parameters):
+def create_json_from_csv(input_directory, filename, parameters,
+                         storage = False):
 
     """
     One csv file is loaded and it's parameters are checked. The csv file is
@@ -285,10 +286,13 @@ def create_json_from_csv(input_directory, filename, parameters):
     :param input_directory: str
         path of the directory where the input csv files can be found
     :param filename: str
-        name of the inputfile that is transformed into a json, without
+        name of the input file that is transformed into a json, without
         extension
     :param parameters: list
         List of parameters names that are required
+    :param storage: bool
+        default value is False. If the function is called by add_storage() the
+        parameter storage is set to True
     :return: dict
         the converted dictionary
     """
@@ -390,7 +394,8 @@ def create_json_from_csv(input_directory, filename, parameters):
             single_dict.update({column: column_dict})
             # add exception for energyStorage
             if filename == "energyStorage":
-                storage_dict = add_storage(column, input_directory)
+                storage_dict = add_storage(df.loc["storage_filename"][column][:-4],
+                                           input_directory)
                 single_dict[column].update(storage_dict)
 
     logging.info(
@@ -406,7 +411,7 @@ def create_json_from_csv(input_directory, filename, parameters):
         "simulation_settings",
     ]:
         return single_dict
-    elif "storage_" in filename:
+    elif storage == True:
         return single_dict
     else:
         single_dict2.update({filename: single_dict})
@@ -495,6 +500,7 @@ def add_storage(storage_filename, input_directory):
             "unit",
         ]
         single_dict = create_json_from_csv(
-            input_directory, filename=storage_filename, parameters=parameters
+            input_directory, filename=storage_filename, parameters=parameters,
+            storage=True
         )
         return single_dict

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -290,7 +290,8 @@ def create_json_from_csv(input_directory, filename, parameters, storage=False):
     :param parameters: list
         List of parameters names that are required
     :param storage: bool
-        default value is False. If the function is called by add_storage() the
+        default value is False. If the function is called by
+        add_storage_components() the
         parameter storage is set to True
     :return: dict
         the converted dictionary
@@ -393,7 +394,7 @@ def create_json_from_csv(input_directory, filename, parameters, storage=False):
             single_dict.update({column: column_dict})
             # add exception for energyStorage
             if filename == "energyStorage":
-                storage_dict = add_storage(
+                storage_dict = add_storage_components(
                     df.loc["storage_filename"][column][:-4], input_directory
                 )
                 single_dict[column].update(storage_dict)
@@ -466,7 +467,7 @@ def conversion(filename, column_dict, row, i, column, value):
     return column_dict
 
 
-def add_storage(storage_filename, input_directory):
+def add_storage_components(storage_filename, input_directory):
 
     """
     loads the csv of a the specific storage listed as column in

--- a/tests/inputs/csv_elements/energyStorage.csv
+++ b/tests/inputs/csv_elements/energyStorage.csv
@@ -4,5 +4,5 @@ label,str,ESS Li-Ion
 optimizeCap,bool,True
 outflow_direction,str,ESS Li-Ion
 type_oemof,str,storage
-storage_filename,str,storage01.csv
+storage_filename,str,storage_01.csv
 energyVector,str,Electricity


### PR DESCRIPTION
Fix #166

**Changes proposed in this pull request**:
- the seperate storage files are not loaded by its column name but by the storage_filename in energyStorage. 
- A new "storage" parameter is introduced to identify storage files without knowing their names. 

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if tests pass


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
