### PR TITLE
Move mvs_csv_config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ Here is a template for new release sections
 - File `troubleshooting.rst` to readthedocs
 - Tests for the module C1 (only used function) (#152)
 - Save network graph as png to output folder if new parameter `store_nx_graph` is true (#242)
-- Tests for the module B0 (#140)
+- Tests for the module B0 (#140, #255)
+- Possibility to move the json file after reading it (useful if json file created from csv files
+) (#255)
 
 ### Changed
 - Shore power randomization improved + amount of available docks can be chosen (#202)
@@ -35,7 +37,6 @@ Here is a template for new release sections
 - Update json file `mvs_config.json`: Default with no peak demand pricing. Replace string "False" by boolean `false`. Remove depreciated parameters from `simulation_settings`(`input_file_name`, `overwrite`, `path_input_file`, `path_input_folder`, `path_input_sequences`, `path_output_folder`, `path_output_folder_inputs`) (#234)
 - Renamed `plot_nx_graph` to `display_nx_graph` and added `store_nx_graph` (#242)
 - variables `required_files_list` and `ALLOWED_FILES` have been replaced by `REQUIRED_FILES` (#251)
-
 ### Removed
 
 ### Fixed

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -102,8 +102,11 @@ def main(**kwargs):
     #    # todo: is user input completely used?
     #    dict_values = data_input.load_json(user_input["path_input_file"])
 
+    move_copy_config_file = False
+
     if user_input["input_type"] == CSV_EXT:
         logging.debug("Accessing script: A1_csv_to_json")
+        move_copy_config_file = True
         load_data_from_csv.create_input_json(
             input_directory=os.path.join(user_input["path_input_folder"], CSV_ELEMENTS),
             output_filename=CSV_FNAME,
@@ -114,6 +117,7 @@ def main(**kwargs):
         user_input["path_input_file"],
         path_input_folder=user_input["path_input_folder"],
         path_output_folder=user_input["path_output_folder"],
+        move_copy=move_copy_config_file,
     )
 
     print("")

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from src.constants import CSV_FNAME, INPUTS_COPY
+
 """
 This module is used to open a json file and parse it as a dict all input parameters for the energy 
 system.
@@ -12,13 +14,15 @@ It will be an interface to the EPA.
 
 
 def load_json(
-    path_input_file, path_input_folder=None, path_output_folder=None,
+    path_input_file, path_input_folder=None, path_output_folder=None, move_copy=True
 ):
     """Opens and reads json input file and parses it to dict of input parameters.
 
-    :param path_input_file:
-    :param path_input_folder:
-    :param path_output_folder:
+    path_input_file: str
+    path_input_folder: str, optional
+    path_output_folder: str, optional
+    move_copy: bool, optional
+        if this is set to True, the path_input_file will be moved to the path_output_folder
     :return: dict of all input parameters
     """
     with open(path_input_file) as json_file:
@@ -32,7 +36,16 @@ def load_json(
     if path_output_folder is not None:
         dict_values["simulation_settings"]["path_output_folder"] = path_output_folder
         dict_values["simulation_settings"]["path_output_folder_inputs"] = os.path.join(
-            path_output_folder, "inputs"
+            path_output_folder, INPUTS_COPY
+        )
+
+    if move_copy is True:
+        os.replace(
+            path_input_file,
+            os.path.join(
+                dict_values["simulation_settings"]["path_output_folder_inputs"],
+                CSV_FNAME,
+            ),
         )
 
     return dict_values

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -14,7 +14,7 @@ It will be an interface to the EPA.
 
 
 def load_json(
-    path_input_file, path_input_folder=None, path_output_folder=None, move_copy=True
+    path_input_file, path_input_folder=None, path_output_folder=None, move_copy=False
 ):
     """Opens and reads json input file and parses it to dict of input parameters.
 

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -18,12 +18,26 @@ def load_json(
 ):
     """Opens and reads json input file and parses it to dict of input parameters.
 
+    Parameters
+    ----------
+
     path_input_file: str
-    path_input_folder: str, optional
-    path_output_folder: str, optional
+        The path to the json file created from csv files
+    path_input_folder : str, optional
+        The path to the directory where the input CSVs/JSON files are located.
+        Default: 'inputs/'.
+    path_output_folder : str, optional
+        The path to the directory where the results of the simulation such as
+        the plots, time series, results JSON files are saved by MVS E-Lands.
+        Default: 'MVS_outputs/'
     move_copy: bool, optional
         if this is set to True, the path_input_file will be moved to the path_output_folder
-    :return: dict of all input parameters
+        Default: False
+
+    Returns
+    -------
+
+    dict of all input parameters of the MVS E-Lands simulation
     """
     with open(path_input_file) as json_file:
         dict_values = json.load(json_file)
@@ -39,6 +53,7 @@ def load_json(
             path_output_folder, INPUTS_COPY
         )
 
+    # Move the json file created from csv to the copy of the input folder in the output folder
     if move_copy is True:
         os.replace(
             path_input_file,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,9 +1,19 @@
 import os
 
 # import constants from src
-from src.constants import INPUT_FOLDER, JSON_FNAME, CSV_ELEMENTS, INPUTS_COPY
+from src.constants import (
+    INPUT_FOLDER,
+    JSON_FNAME,
+    CSV_ELEMENTS,
+    INPUTS_COPY,
+    CSV_FNAME,
+    CSV_EXT,
+)
 
 TEST_REPO_PATH = os.path.dirname(__file__)
 
 CSV_PATH = os.path.join(TEST_REPO_PATH, INPUT_FOLDER, CSV_ELEMENTS)
 JSON_PATH = os.path.join(TEST_REPO_PATH, INPUT_FOLDER, JSON_FNAME)
+
+# path of the file created automatically by
+JSON_CSV_PATH = os.path.join(TEST_REPO_PATH, INPUT_FOLDER, CSV_ELEMENTS, CSV_FNAME)

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -1,7 +1,20 @@
 import os
+import shutil
+import mock
 
-from .constants import JSON_PATH
+from .constants import (
+    TEST_REPO_PATH,
+    JSON_PATH,
+    CSV_PATH,
+    CSV_FNAME,
+    CSV_ELEMENTS,
+    JSON_CSV_PATH,
+    INPUTS_COPY,
+    CSV_EXT,
+)
 
+import src.A0_initialization as initializing
+import src.A1_csv_to_json as load_data_from_csv
 import src.B0_data_input_json as data_input
 
 
@@ -16,3 +29,80 @@ def test_load_json_overwrite_output_folder_from_json():
 def test_load_json_overwrite_input_folder_from_json():
     dict_values = data_input.load_json(JSON_PATH, path_input_folder="test")
     assert dict_values["simulation_settings"]["path_input_folder"] == "test"
+
+
+PARSER = initializing.create_parser()
+
+
+class TestTemporaryJsonFileDisposal:
+
+    test_in_path = os.path.join("tests", "inputs")
+    test_out_path = os.path.join(".", "tests", "MVS_outputs")
+
+    @mock.patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=PARSER.parse_args(
+            ["-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+        ),
+    )
+    def test_load_json_removes_json_file_from_inputs_folder(self, m_args):
+        initializing.process_user_arguments()
+
+        load_data_from_csv.create_input_json(
+            input_directory=CSV_PATH, output_filename=CSV_FNAME, pass_back=True
+        )
+        dict_values = data_input.load_json(
+            JSON_CSV_PATH, path_output_folder=self.test_out_path
+        )
+
+        assert (
+            os.path.exists(
+                os.path.join(
+                    dict_values["simulation_settings"]["path_input_folder"],
+                    CSV_ELEMENTS,
+                    CSV_FNAME,
+                )
+            )
+            is False
+        )
+
+        assert (
+                os.path.exists(
+                    os.path.join(
+                        dict_values["simulation_settings"]["path_input_folder"],
+                        CSV_FNAME,
+                    )
+                )
+                is False
+        )
+
+
+    @mock.patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=PARSER.parse_args(
+            ["-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+        ),
+    )
+    def test_load_json_copies_json_file_to_output_folder(self, m_args):
+        initializing.process_user_arguments()
+
+        load_data_from_csv.create_input_json(
+            input_directory=CSV_PATH, output_filename=CSV_FNAME, pass_back=True
+        )
+        dict_values = data_input.load_json(
+            JSON_CSV_PATH, path_output_folder=self.test_out_path
+        )
+
+        assert (
+                os.path.exists(
+                    os.path.join(
+                        dict_values["simulation_settings"]["path_output_folder_inputs"],
+                        CSV_FNAME,
+                    )
+                )
+                is True
+        )
+
+    def teardown_method(self):
+        if os.path.exists(self.test_out_path):
+            shutil.rmtree(self.test_out_path, ignore_errors=True)

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -52,7 +52,7 @@ class TestTemporaryJsonFileDisposal:
             input_directory=CSV_PATH, output_filename=CSV_FNAME, pass_back=True
         )
         dict_values = data_input.load_json(
-            JSON_CSV_PATH, path_output_folder=self.test_out_path
+            JSON_CSV_PATH, path_output_folder=self.test_out_path, move_copy=True
         )
 
         assert (
@@ -67,15 +67,13 @@ class TestTemporaryJsonFileDisposal:
         )
 
         assert (
-                os.path.exists(
-                    os.path.join(
-                        dict_values["simulation_settings"]["path_input_folder"],
-                        CSV_FNAME,
-                    )
+            os.path.exists(
+                os.path.join(
+                    dict_values["simulation_settings"]["path_input_folder"], CSV_FNAME,
                 )
-                is False
+            )
+            is False
         )
-
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -90,17 +88,17 @@ class TestTemporaryJsonFileDisposal:
             input_directory=CSV_PATH, output_filename=CSV_FNAME, pass_back=True
         )
         dict_values = data_input.load_json(
-            JSON_CSV_PATH, path_output_folder=self.test_out_path
+            JSON_CSV_PATH, path_output_folder=self.test_out_path, move_copy=True
         )
 
         assert (
-                os.path.exists(
-                    os.path.join(
-                        dict_values["simulation_settings"]["path_output_folder_inputs"],
-                        CSV_FNAME,
-                    )
+            os.path.exists(
+                os.path.join(
+                    dict_values["simulation_settings"]["path_output_folder_inputs"],
+                    CSV_FNAME,
                 )
-                is True
+            )
+            is True
         )
 
     def teardown_method(self):


### PR DESCRIPTION
Fix #167 

**Changes proposed in this pull request**:
- Add an argument to the function `load_json` in order to move the json file after reading it

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- :x: For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if tests pass

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
