### PR TITLE
Fix command line argument bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
@@ -27,12 +28,12 @@ release = "0.0.2"
 
 # -- General configuration ---------------------------------------------------
 
-master_doc = 'index'
+master_doc = "index"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.coverage", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/mvs_eland_tool/mvs_eland_tool.py
+++ b/mvs_eland_tool/mvs_eland_tool.py
@@ -74,10 +74,6 @@ def main(**kwargs):
 
     """
 
-    for k, v in DEFAULT_MAIN_KWARGS.items():
-        if k not in kwargs:
-            kwargs[k] = v
-
     version = (
         "0.2.0"  # update_me Versioning scheme: Major release.Minor release.Patches
     )

--- a/src/A0_initialization.py
+++ b/src/A0_initialization.py
@@ -249,7 +249,8 @@ def process_user_arguments(
     parser = create_parser()
     args = vars(parser.parse_args())
 
-    # Give priority from kwargs over command line arguments
+    # Give priority from user input kwargs over command line arguments
+    # However the command line arguments have priority over default kwargs
     if path_input_folder is None:
         path_input_folder = args.get(
             "path_input_folder", DEFAULT_MAIN_KWARGS["path_input_folder"]

--- a/src/A0_initialization.py
+++ b/src/A0_initialization.py
@@ -41,6 +41,7 @@ from src.constants import (
     CSV_EXT,
     CSV_ELEMENTS,
     INPUTS_COPY,
+    DEFAULT_MAIN_KWARGS,
 )
 
 from oemof.tools import logger
@@ -250,19 +251,25 @@ def process_user_arguments(
 
     # Give priority from kwargs over command line arguments
     if path_input_folder is None:
-        path_input_folder = args.get("path_input_folder")
+        path_input_folder = args.get(
+            "path_input_folder", DEFAULT_MAIN_KWARGS["path_input_folder"]
+        )
 
     if input_type is None:
-        input_type = args.get("input_type")
+        input_type = args.get("input_type", DEFAULT_MAIN_KWARGS["input_type"])
 
     if path_output_folder is None:
-        path_output_folder = args.get("path_output_folder")
+        path_output_folder = args.get(
+            "path_output_folder", DEFAULT_MAIN_KWARGS["path_output_folder"]
+        )
 
     if overwrite is None:
-        overwrite = args.get("overwrite")
+        overwrite = args.get("overwrite", DEFAULT_MAIN_KWARGS["overwrite"])
 
     if display_output is None:
-        display_output = args.get("display_output")
+        display_output = args.get(
+            "display_output", DEFAULT_MAIN_KWARGS["display_output"]
+        )
 
     path_input_file = check_input_folder(path_input_folder, input_type)
     check_output_folder(path_input_folder, path_output_folder, overwrite)


### PR DESCRIPTION
The command line options were completely ignored

The command line arguments were completely ignored due to providing default kwargs (introduced in 0702e1b7b7f44116023c1b58554cbc1c353baa31)

**Changes proposed in this pull request**:
- Only assign the default kwargs if no command line arguments were provided

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- :x: Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- :x: Write test(s) for your new patch of code
- :x: Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`pytest tests/test_benchmark.py`)

:x: Check not applicable to this PR
