### PR TITLE
Improve benchmark tests

### DIFF
--- a/inputs/csv_elements/simulation_settings.csv
+++ b/inputs/csv_elements/simulation_settings.csv
@@ -1,5 +1,5 @@
 ,unit,simulation_settings
-evaluated_period,days,365
+evaluated_period,days,2
 label,str,simulation_settings
 oemof_file_name,str,MVS_results.oemof
 output_lp_file,bool,False

--- a/inputs/mvs_config.json
+++ b/inputs/mvs_config.json
@@ -654,7 +654,7 @@
     "simulation_settings": {
         "evaluated_period": {
             "unit": "days",
-            "value": 365
+            "value": 2
         },
         "label": "simulation_settings",
         "oemof_file_name": "MVS_results.oemof",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -15,37 +15,35 @@ from .constants import TEST_REPO_PATH, JSON_EXT, CSV_EXT
 from mvs_eland_tool.mvs_eland_tool import main
 
 OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "MVS_outputs_simulation")
-
-
-def setup_module():
-    if os.path.exists(OUTPUT_PATH):
-        shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
-
-
 fname = os.path.basename(__file__)
 
-# this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
-# alone it called
-@pytest.mark.skipif(
-    "tests/{}".format(fname) not in sys.argv, reason="requires python3.3"
-)
-@mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
-def test_run_smoothly_json(mock_args):
-    main(input_type=JSON_EXT, path_output_folder=OUTPUT_PATH)
-    # TODO: find typical output values to write better test, currently it only test that main() run
-    # TODO: without crashing, but does not test if the output make sense
-    assert 1 == 1
 
+class TestSimulation:
 
-@pytest.mark.skipif(
-    "tests/{}".format(fname) not in sys.argv, reason="requires python3.3"
-)
-@mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
-def test_run_smoothly_csv(mock_args):
-    main(input_type=CSV_EXT, path_output_folder=OUTPUT_PATH, overwrite=True)
-    assert 1 == 1
+    def setup_method(self):
+        if os.path.exists(OUTPUT_PATH):
+            shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
 
+    # this ensure that the test is only ran if explicitly executed, ie not when the `pytest` command
+    # alone it called
+    @pytest.mark.skipif(
+        "tests/{}".format(fname) not in sys.argv, reason="requires python3.3"
+    )
+    @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
+    def test_run_smoothly_json(self, mock_args):
+        main(input_type=JSON_EXT, path_output_folder=OUTPUT_PATH)
+        # TODO: find typical output values to write better test, currently it only test that main() run
+        # TODO: without crashing, but does not test if the output make sense
+        assert 1 == 1
 
-def teardown_module():
-    if os.path.exists(OUTPUT_PATH):
-        shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
+    @pytest.mark.skipif(
+        "tests/{}".format(fname) not in sys.argv, reason="requires python3.3"
+    )
+    @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
+    def test_run_smoothly_csv(self, mock_args):
+        main(input_type=CSV_EXT, path_output_folder=OUTPUT_PATH)
+        assert 1 == 1
+
+    def teardown_method(self):
+        if os.path.exists(OUTPUT_PATH):
+            shutil.rmtree(OUTPUT_PATH, ignore_errors=True)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -19,7 +19,6 @@ fname = os.path.basename(__file__)
 
 
 class TestSimulation:
-
     def setup_method(self):
         if os.path.exists(OUTPUT_PATH):
             shutil.rmtree(OUTPUT_PATH, ignore_errors=True)


### PR DESCRIPTION
Fix #260 

**Changes proposed in this pull request**:
- Change the default number of days of the simulation to 2, so it takes much less time to test a whole simulation

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`pytest tests/test_benchmark.py`)

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
