### PR TITLE
Add tests for storage in A1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 - Benchmark test with only PV and grid (#258)
 - Module F2 for auto-reporting results of MVS simulation (#232)
 - Tests for module C2 (#151)
-- Test for storage for the module A1 (#299)
+- Tests for storage for the module A1 (#299)
 
 ### Changed
 - Shore power randomization improved + amount of available docks can be chosen (#202)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 - Benchmark test with only PV and grid (#258)
 - Module F2 for auto-reporting results of MVS simulation (#232)
 - Tests for module C2 (#151)
+- Test for storage for the module A1 (#299)
 
 ### Changed
 - Shore power randomization improved + amount of available docks can be chosen (#202)
@@ -56,6 +57,7 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 - Seperated functions in F0 to ease testing (#142)
 - Moved some functions between F0 and F1, rearranged functions in F1 (#157)
 - Call timeseries plot function for each bus (#278)
+- rename "storage" paremeter in A1 and Tests_A1 to "asset_is_a_storage"
  
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 - Seperated functions in F0 to ease testing (#142)
 - Moved some functions between F0 and F1, rearranged functions in F1 (#157)
 - Call timeseries plot function for each bus (#278)
-- rename "storage" paremeter in A1 and Tests_A1 to "asset_is_a_storage"
+- rename "storage" parameter in A1 and tests_A1 to "asset_is_a_storage"
  
 ### Removed
 
@@ -200,4 +200,3 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 
 ### Removed
 - yet another thing
-

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -266,7 +266,7 @@ def create_json_from_csv(
             column_dict = {}
             # the storage columns are checked for the right parameters,
             # Nan values that are not needed are deleted
-            if asset_is_a_storage == True:
+            if asset_is_a_storage is True:
                 # check if all three columns are available
                 if len(df_copy.columns) < 4 or len(df_copy.columns) > 4:
                     logging.error(

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -141,7 +141,8 @@ def create_input_json(
         return outfile.name
 
 
-def create_json_from_csv(input_directory, filename, parameters=None, storage=False):
+def create_json_from_csv(input_directory, filename, parameters=None,
+                         asset_is_a_storage =False):
 
     """
     One csv file is loaded and it's parameters are checked. The csv file is
@@ -161,7 +162,7 @@ def create_json_from_csv(input_directory, filename, parameters=None, storage=Fal
         extension
     :param parameters: list
         List of parameters names that are required
-    :param storage: bool
+    :param asset_is_a_storage : bool
         default value is False. If the function is called by
         add_storage_components() the
         parameter is set to True
@@ -219,7 +220,7 @@ def create_json_from_csv(input_directory, filename, parameters=None, storage=Fal
     # check parameters
     missing_parameters = []
     wrong_parameters = []
-    if storage is False:
+    if asset_is_a_storage is False:
         extra = list(set(parameters) ^ set(df.index))
         if len(extra) > 0:
             for i in extra:
@@ -258,7 +259,7 @@ def create_json_from_csv(input_directory, filename, parameters=None, storage=Fal
             column_dict = {}
             # the storage columns are checked for the right parameters,
             # Nan values that are not needed are deleted
-            if storage == True:
+            if asset_is_a_storage == True:
                 # check if all three columns are available
                 if len(df_copy.columns) < 4 or len(df_copy.columns) > 4:
                     logging.error(
@@ -424,7 +425,7 @@ def create_json_from_csv(input_directory, filename, parameters=None, storage=Fal
         "simulation_settings",
     ]:
         return single_dict
-    elif storage is True:
+    elif asset_is_a_storage is True:
         return single_dict
     else:
         single_dict2 = {}
@@ -510,6 +511,6 @@ def add_storage_components(storage_filename, input_directory):
             input_directory,
             filename=storage_filename,
             parameters=parameters,
-            storage=True,
+            asset_is_a_storage =True,
         )
         return single_dict

--- a/src/A1_csv_to_json.py
+++ b/src/A1_csv_to_json.py
@@ -317,7 +317,7 @@ def create_json_from_csv(
                         elif pd.isnull(df_copy.at[i, column]) is False:
                             warnings.warn(
                                 WrongParameterWarning(
-                                    f"The storage parameter {str(i)} in column "
+                                    f"The storage parameter {i} in column "
                                     f" {column} of the file {filename}.csv should "
                                     "be set to NaN. It will not be considered in the "
                                     "simulation"
@@ -334,7 +334,7 @@ def create_json_from_csv(
                     elif pd.isnull(df_copy.at[i, column]) is True:
                         warnings.warn(
                             WrongParameterWarning(
-                                f"In file {filename}.csv the parameter {str(i)}"
+                                f"In file {filename}.csv the parameter {i}"
                                 f" in column {column} is NaN. Please insert a value "
                                 "of 0 or int. For this "
                                 "simulation the value is set to 0 "

--- a/tests/test_A1_csv_to_json.py
+++ b/tests/test_A1_csv_to_json.py
@@ -72,14 +72,14 @@ def test_create_json_from_csv_file_not_exist_raises_filenotfound_error():
 
 def test_create_json_from_csv_with_comma_separated_csv():
     d = A1.create_json_from_csv(
-        DUMMY_CSV_PATH, "csv_comma", CSV_PARAMETERS, storage=False
+        DUMMY_CSV_PATH, "csv_comma", CSV_PARAMETERS, asset_is_a_storage=False
     )
     assert d == {"csv_comma": CSV_EXAMPLE}
 
 
 def test_create_json_from_csv_with_semicolon_separated_csv():
     d = A1.create_json_from_csv(
-        DUMMY_CSV_PATH, "csv_semicolon", CSV_PARAMETERS, storage=False
+        DUMMY_CSV_PATH, "csv_semicolon", CSV_PARAMETERS, asset_is_a_storage=False
     )
 
     assert d == {"csv_semicolon": CSV_EXAMPLE}
@@ -87,7 +87,7 @@ def test_create_json_from_csv_with_semicolon_separated_csv():
 
 def test_create_json_from_csv_with_ampersand_separated_csv():
     d = A1.create_json_from_csv(
-        DUMMY_CSV_PATH, "csv_ampersand", CSV_PARAMETERS, storage=False
+        DUMMY_CSV_PATH, "csv_ampersand", CSV_PARAMETERS, asset_is_a_storage=False
     )
 
     assert d == {"csv_ampersand": CSV_EXAMPLE}
@@ -97,7 +97,10 @@ def test_create_json_from_csv_with_unknown_separator_for_csv_raises_CsvParsingEr
 
     with pytest.raises(A1.CsvParsingError):
         A1.create_json_from_csv(
-            DUMMY_CSV_PATH, "csv_unknown_separator", CSV_PARAMETERS, storage=False
+            DUMMY_CSV_PATH,
+            "csv_unknown_separator",
+            CSV_PARAMETERS,
+            asset_is_a_storage=False,
         )
 
 
@@ -105,18 +108,18 @@ def test_create_json_from_csv_without_providing_parameters_raises_MissingParamet
 
     with pytest.raises(A1.MissingParameterError):
         A1.create_json_from_csv(
-            DUMMY_CSV_PATH, "csv_comma", parameters=[], storage=False
+            DUMMY_CSV_PATH, "csv_comma", parameters=[], asset_is_a_storage=False
         )
 
 
-def test_create_json_from_csv_with_uncomplete_parameters_raises_MissingParameterError():
+def test_create_json_from_csv_with_uncomplete_parameters_raises_WrongParameterWarning():
 
     with pytest.raises(A1.MissingParameterError):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_comma",
             parameters=["param1", "param2", "param3"],
-            storage=False,
+            asset_is_a_storage=False,
         )
 
 
@@ -127,7 +130,7 @@ def test_create_json_from_csv_with_wrong_parameters_raises_WrongParameterWarning
             DUMMY_CSV_PATH,
             "csv_wrong_parameter",
             parameters=["param1", "param2"],
-            storage=False,
+            asset_is_a_storage=False,
         )
 
 
@@ -137,7 +140,7 @@ def test_create_json_from_csv_ignore_extra_parameters_in_csv():
         DUMMY_CSV_PATH,
         "csv_wrong_parameter",
         parameters=["param1", "param2"],
-        storage=False,
+        asset_is_a_storage=False,
     )
     assert d == {"csv_wrong_parameter": CSV_EXAMPLE}
 
@@ -145,7 +148,10 @@ def test_create_json_from_csv_ignore_extra_parameters_in_csv():
 def test_create_json_from_csv_for_time_series():
 
     d = A1.create_json_from_csv(
-        DUMMY_CSV_PATH, "csv_timeseries", parameters=["param1"], storage=False,
+        DUMMY_CSV_PATH,
+        "csv_timeseries",
+        parameters=["param1"],
+        asset_is_a_storage=False,
     )
     for k, v in d["csv_timeseries"]["col1"].items():
         assert v == CSV_TIMESERIES[k]
@@ -157,7 +163,7 @@ def test_create_json_from_csv_for_list():
         DUMMY_CSV_PATH,
         "csv_list",
         parameters=["param1", "param2", "param3", "param4", "param5"],
-        storage=False,
+        asset_is_a_storage=False,
     )
     for k, v in d["csv_list"]["col1"].items():
         assert v == CSV_LIST[k]
@@ -180,10 +186,63 @@ def test_conversion():
             "param_bool6",
             "param_year",
         ],
-        storage=False,
+        asset_is_a_storage=False,
     )
     for k, v in d["csv_type"]["col1"].items():
         assert v == CONVERSION_TYPE[k]
+
+
+def test_create_json_from_csv_storage_raises_WrongParameterWarning():
+
+    with pytest.warns(A1.WrongParameterWarning):
+        A1.create_json_from_csv(
+            DUMMY_CSV_PATH,
+            "csv_storage_wrong_parameter",
+            parameters=["age_installed", "capex_fix"],
+            asset_is_a_storage=True,
+        )
+
+
+def test_create_json_from_csv_storage_raises_MissingParameterError():
+
+    with pytest.raises(A1.MissingParameterError):
+        A1.create_json_from_csv(
+            DUMMY_CSV_PATH,
+            "csv_storage_wrong_parameter",
+            parameters=[
+                "age_installed",
+                "capex_fix",
+                "c_rate",
+                "opex_var",
+                "soc_initial",
+                "soc_max",
+                "soc_min",
+                "installedCap",
+            ],
+            asset_is_a_storage=True,
+        )
+
+
+def test_create_json_from_csv_storage_raises_WrongParameterWarning_for_wrong_values():
+
+    with pytest.warns(A1.WrongParameterWarning):
+        A1.create_json_from_csv(
+            DUMMY_CSV_PATH,
+            "csv_storage_wrong_values",
+            parameters=["age_installed", "capex_fix"],
+            asset_is_a_storage=True,
+        )
+
+
+def test_create_json_from_csv_storage_raises_WrongStorageColumn():
+
+    with pytest.raises(A1.WrongStorageColumn):
+        A1.create_json_from_csv(
+            DUMMY_CSV_PATH,
+            "csv_storage_wrong_column_name",
+            parameters=["age_installed", "capex_fix"],
+            asset_is_a_storage=True,
+        )
 
 
 def teardown_function():

--- a/tests/test_data/csv_storage_wrong_column_name.csv
+++ b/tests/test_data/csv_storage_wrong_column_name.csv
@@ -1,0 +1,9 @@
+,unit,storage capacity,input power,wrong
+age_installed,str,val11,val22,val33
+capex_fix,factor,21,22,23
+c_rate,factor of total capacity (kWh),1,1,1
+opex_var,currency/kWh,NaN,0,0
+soc_initial,None or factor,None,NaN,NaN
+soc_max,factor,1.0,NaN,NaN
+soc_min,factor,0.2,NaN,NaN
+wrong_parameter,str,wrong,wrong,wong

--- a/tests/test_data/csv_storage_wrong_parameter.csv
+++ b/tests/test_data/csv_storage_wrong_parameter.csv
@@ -1,0 +1,9 @@
+,unit,storage capacity,input power,output power
+age_installed,str,val11,val22,val33
+capex_fix,factor,21,22,23
+c_rate,factor of total capacity (kWh),NaN,1,1
+opex_var,currency/kWh,NaN,0,0
+soc_initial,None or factor,None,NaN,NaN
+soc_max,factor,1.0,NaN,NaN
+soc_min,factor,0.2,NaN,NaN
+wrong_parameter,str,wrong,wrong,wong

--- a/tests/test_data/csv_storage_wrong_values.csv
+++ b/tests/test_data/csv_storage_wrong_values.csv
@@ -1,0 +1,9 @@
+,unit,storage capacity,input power,output power
+age_installed,str,val11,val22,val33
+capex_fix,factor,21,22,23
+c_rate,factor of total capacity (kWh),1,1,1
+opex_var,currency/kWh,NaN,0,0
+soc_initial,None or factor,None,NaN,NaN
+soc_max,factor,1.0,NaN,NaN
+soc_min,factor,0.2,NaN,NaN
+wrong_parameter,str,wrong,wrong,wong


### PR DESCRIPTION
Fix #299 

**Changes proposed in this pull request**:
- change parameter "storage" in A1 and Tests_A1 to "asset_is_a_storage"
- new tests for the storage in Test_A1
- adapt warning names in A1

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`pytest tests/test_benchmark.py`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
