### PR TITLE
Fix/json series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ tipps for module building, and hint that units in the MVS are not checked (PR #2
 - rename "storage" parameter in A1 and tests_A1 to "asset_is_a_storage"
 - Serialize the DataFrame and arrays into the json_with_results.json (#304)
 - Convert serialized DataFrame and arrays back into these types in the B0.load_json function
- (#304, #322)
+ (#304, #322, #326)
 - The input from the csv files produce the same json than the json file (#286)
  - Move the CSS styling code to a style sheet (#317)
 ### Removed

--- a/src/B0_data_input_json.py
+++ b/src/B0_data_input_json.py
@@ -66,7 +66,21 @@ def convert_special_types(a_dict, prev_key=None):
             elif TYPE_SERIES in a_dict:
                 # pandas.Series
                 a_dict = a_dict.replace(TYPE_SERIES, "")
+                # extract the name of the series in case it was a tuple
+                a_dict = json.loads(a_dict)
+                name = a_dict.pop("name")
+
+                # reconvert the dict to a json for conversion to pandas Series
+                a_dict = json.dumps(a_dict)
                 answer = pd.read_json(a_dict, orient="split", typ="series")
+
+                # if the name was a tuple it was converted to a list via json serialization
+                if isinstance(name, list):
+                    name[0] = tuple(name[0])
+                    name = tuple(name)
+
+                if name is not None:
+                    answer.name = name
 
             elif TYPE_TIMESTAMP in a_dict:
                 a_dict = a_dict.replace(TYPE_TIMESTAMP, "")

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -46,7 +46,9 @@ VALUES = [0, 1, 2]
 
 pandas_DatetimeIndex = pd.date_range(start=START_TIME, periods=PERIODS, freq="60min")
 pandas_Series = pd.Series(VALUES, index=pandas_DatetimeIndex)
-pandas_Series_tuple_name = pd.Series(VALUES, index=pandas_DatetimeIndex, name=(("A", "B"), "flow"))
+pandas_Series_tuple_name = pd.Series(
+    VALUES, index=pandas_DatetimeIndex, name=(("A", "B"), "flow")
+)
 pandas_Dataframe = pd.DataFrame({"a": VALUES, "b": VALUES})
 SCALAR = 2
 

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -46,6 +46,7 @@ VALUES = [0, 1, 2]
 
 pandas_DatetimeIndex = pd.date_range(start=START_TIME, periods=PERIODS, freq="60min")
 pandas_Series = pd.Series(VALUES, index=pandas_DatetimeIndex)
+pandas_Series_tuple_name = pd.Series(VALUES, index=pandas_DatetimeIndex, name=(("A", "B"), "flow"))
 pandas_Dataframe = pd.DataFrame({"a": VALUES, "b": VALUES})
 SCALAR = 2
 
@@ -56,6 +57,7 @@ JSON_TEST_DICTIONARY = {
     "pandas_DatetimeIndex": pandas_DatetimeIndex,
     "pandas_Timestamp": pd.Timestamp(START_TIME),
     "pandas_series": pandas_Series,
+    "pandas_series_tuple_name": pandas_Series_tuple_name,
     "numpy_array": np.array(VALUES),
     "pandas_Dataframe": pandas_Dataframe,
 }
@@ -303,6 +305,11 @@ class TestLoadDictionaryFromJson:
     def test_load_json_parse_pandas_series(self):
         """ """
         k = "pandas_series"
+        assert self.value_dict[k].equals(JSON_TEST_DICTIONARY[k])
+
+    def test_load_json_parse_pandas_series_tuple_name(self):
+        """ """
+        k = "pandas_series_tuple_name"
         assert self.value_dict[k].equals(JSON_TEST_DICTIONARY[k])
 
     def test_load_json_parse_numpy_array(self):


### PR DESCRIPTION
Fix #325 

**Changes proposed in this pull request**:
- Modify the `convert special types` function to allow retro conversion of `tuples` type of the `pandas.Series` `name` attribute.

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
