### PR TITLE
Add function to write sensitivity tests

### DIFF
--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -173,6 +173,6 @@ def single_param_variation_analysis(
 if __name__ == "__main__":
     single_param_variation_analysis(
         [1, 2, 3, 4, 5, 6, 7],
-        JSON_PATH,
+        os.path.join(TEST_REPO_PATH, "benchmark_test_inputs", "rerun", "mvs_config.json"),
         ("simulation_settings", "evaluated_period", "value"),
     )

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -73,3 +73,41 @@ def get_nested_value(dct, keys):
         raise TypeError("The argument 'keys' from get_nested_value() should be a tuple")
     return answer
 
+
+def split_nested_path(path):
+    r"""Separate a single-string path in a nested dict in a list of keys
+
+
+    Parameters
+    ----------
+    path: str or tuple
+        path within a nested dict which is expressed as a str of a succession of keys separated by
+        a `.` or a `,`. The order of keys is to be read from left to right.
+
+    Returns
+    -------
+    Tuple containing the succession of keys which lead to the value within the nested dict
+
+    """
+    SEPARATORS = (".", ",")
+    keys_list = None
+    if isinstance(path, str):
+        separator_count = 0
+        keys_separator = None
+        for separator in SEPARATORS:
+            if separator in path:
+                if path.count(separator) > 0:
+                    if separator_count > 0:
+                        raise ValueError(
+                            f"The separator of the nested dict's path is not unique"
+                        )
+                    separator_count = path.count(separator)
+                    keys_separator = separator
+        if keys_separator is not None:
+            keys_list = tuple(path.split(keys_separator))
+    elif isinstance(path, tuple):
+        keys_list = path
+    else:
+        raise TypeError("The argument path is not str type")
+
+    return keys_list

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,75 @@
+"""
+In this module the tests run over whole simulation from main, not just single functions of modules
+
+What should differ between the different functions is the input file
+
+"""
+import copy
+import logging
+import os
+
+from mvs_eland_tool import run_simulation
+from src.B0_data_input_json import load_json
+from tests.constants import JSON_PATH, TEST_REPO_PATH
+
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "MVS_outputs_simulation")
+
+
+def set_nested_value(dct, value, keys):
+    r"""Set a value within a nested dict structure given the path within the dict
+
+    Parameters
+    ----------
+    dct: dict
+        the (potentially nested) dict from which we want to get a value
+    value: variable type
+        value to assign within the dict
+    keys: tuple
+        Tuple containing the succession of keys which lead to the value within the nested dict
+
+    Returns"
+    -------
+    The value under the path within the (potentially nested) dict
+    """
+    if isinstance(keys, tuple) is True:
+        answer = copy.deepcopy(dct)
+        if len(keys) > 1:
+            answer[keys[0]] = set_nested_value(dct[keys[0]], value, keys[1:])
+        elif len(keys) == 1:
+            answer[keys[0]] = value
+        else:
+            raise ValueError(
+                "The tuple argument 'keys' from set_nested_value() should not be empty"
+            )
+    else:
+        raise TypeError("The argument 'keys' from set_nested_value() should be a tuple")
+    return answer
+
+
+def get_nested_value(dct, keys):
+    r"""Get a value from a succession of keys within a nested dict structure
+
+    Parameters
+    ----------
+    dct: dict
+        the (potentially nested) dict from which we want to get a value
+    keys: tuple
+        Tuple containing the succession of keys which lead to the value within the nested dict
+
+    Returns
+    -------
+    The value under the path within the (potentially nested) dict
+    """
+    if isinstance(keys, tuple) is True:
+        if len(keys) > 1:
+            answer = get_nested_value(dct[keys[0]], keys[1:])
+        elif len(keys) == 1:
+            answer = dct[keys[0]]
+        else:
+            raise ValueError(
+                "The tuple argument 'keys' from get_nested_value() should not be empty"
+            )
+    else:
+        raise TypeError("The argument 'keys' from get_nested_value() should be a tuple")
+    return answer
+

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -28,9 +28,15 @@ def set_nested_value(dct, value, keys):
     keys: tuple
         Tuple containing the succession of keys which lead to the value within the nested dict
 
-    Returns"
+    Returns
     -------
     The value under the path within the (potentially nested) dict
+
+    Example
+    -------
+    >>> dct = dict(a=dict(a1=1, a2=2),b=dict(b1=dict(b11=11,b12=dict(b121=121))))
+    >>> print(set_nested_value(dct, 400,("b", "b1", "b12","b121")))
+    {'a': {'a1': 1, 'a2': 2}, 'b': {'b1': {'b11': 11, 'b12': {'b121': 400}}}}
     """
     if isinstance(keys, tuple) is True:
         answer = copy.deepcopy(dct)
@@ -60,6 +66,12 @@ def get_nested_value(dct, keys):
     Returns
     -------
     The value under the path within the (potentially nested) dict
+
+    Example
+    -------
+    >>> dct = dict(a=dict(a1=1, a2=2),b=dict(b1=dict(b11=11,b12=dict(b121=121))))
+    >>> print(get_nested_value(dct, ("b", "b1", "b12","b121")))
+    121
     """
     if isinstance(keys, tuple) is True:
         if len(keys) > 1:
@@ -149,7 +161,7 @@ def single_param_variation_analysis(
         simulation_input = None
         logging.error(
             f"Simulation input `{json_input}` is neither a file path, nor a json dict. "
-            f"It can therefor not be processed."
+            f"It can therefore not be processed."
         )
     param_path_tuple = split_nested_path(json_path_to_param_value)
     answer = []


### PR DESCRIPTION
**Changes proposed in this pull request**:
This is to perform sensitivity test of certain parameters: for example making simulations with fuel prices ranging from price_min to price_max with certain price step, and looking at how one or more of the outputs change versus fuel price. The function `single_param_variation_analysis` is general enough to run N simulations varying one parameter. 
- Add function `get_nested_value` to retrieve a value in a nested json structure
- Add function `set_nested_value` to change a value in a nested json structure

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
