### PR TITLE
Define last global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,15 @@ Here is a template for new release sections
 - All parameters of the json/csv input files are now defined by constant variables (i.e, `CRATE="crate"` instead of string `"crate"`) (#346)
 - Use "is" instead of "==" in if clauses for True, False and None (#346)
 - Categorize constants in 'constants_json_strings.py' (#347)
-- Renaming CAPEX_FIX = "capex_fix" into COST_DEVELOPMENT = "cost_development" (#40)
-- Renaming CAPEX_VAR = "capex_var" into SPECIFIC_COST = "specific_cost" (#40)
-- Renaming OPEX_FIX = "opex_fix" into SPECIFIC_COST_OM = "specific_cost_om" (#40)
-- Renaming OPEX_VAR = "opex_var" into PRICE_DISPATCH = "price_dispatch" (#40)
-- Change into constants into "constants_json_strings.py": "annuity_total", "costs_opex_fix"/"costs_cost_om", "costs_opex_var"/"costs_p_dispatch", "costs_upfront", "costs_total" and "costs_om"
-
+- Renaming CAPEX_FIX = "capex_fix" into COST_DEVELOPMENT = "cost_development" (#347)
+- Renaming CAPEX_VAR = "capex_var" into SPECIFIC_COST = "specific_cost" (#347)
+- Renaming OPEX_FIX = "opex_fix" into SPECIFIC_COST_OM = "specific_cost_om" (#347)
+- Renaming OPEX_VAR = "opex_var" into PRICE_DISPATCH = "price_dispatch" (#347)
+- Change last strings into global constants in "constants_json_strings.py" (#349)
+- Autoreport now refers to actual project and scenario name + ID
 
 ### Removed
+
 
 
 ## [0.2.1] - 2020-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Here is a template for new release sections
 - Renaming CAPEX_VAR = "capex_var" into SPECIFIC_COST = "specific_cost" (#40)
 - Renaming OPEX_FIX = "opex_fix" into SPECIFIC_COST_OM = "specific_cost_om" (#40)
 - Renaming OPEX_VAR = "opex_var" into PRICE_DISPATCH = "price_dispatch" (#40)
+- Change into constants into "constants_json_strings.py": "annuity_total", "costs_opex_fix"/"costs_cost_om", "costs_opex_var"/"costs_p_dispatch", "costs_upfront", "costs_total" and "costs_om"
+
 
 ### Removed
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -919,7 +919,7 @@ def evaluate_lifetime_costs(settings, economic_data, dict_asset):
     # Annuities of components including opex AND capex #
     dict_asset.update(
         {
-            ANNUITY_CAPEX_OPEX_VAR: {
+            ANNUITY_SPECIFIC_INVESTMENT_AND_OM: {
                 VALUE: economics.annuity(
                     dict_asset[LIFETIME_SPECIFIC_COST][VALUE],
                     economic_data[CRF][VALUE],
@@ -944,7 +944,7 @@ def evaluate_lifetime_costs(settings, economic_data, dict_asset):
         {
             SIMULATION_ANNUITY: {
                 VALUE: economics.simulation_annuity(
-                    dict_asset[ANNUITY_CAPEX_OPEX_VAR][VALUE],
+                    dict_asset[ANNUITY_SPECIFIC_INVESTMENT_AND_OM][VALUE],
                     settings[EVALUATED_PERIOD][VALUE],
                 ),
                 UNIT: "currency/unit/simulation period",

--- a/src/E0_evaluation.py
+++ b/src/E0_evaluation.py
@@ -30,6 +30,13 @@ from src.constants_json_strings import (
     KPI_SCALARS_DICT,
     TOTAL_FLOW,
     ANNUITY_OM,
+    ANNUITY_TOTAL,
+    COST_TOTAL,
+    COST_OM_TOTAL,
+    COST_INVESTMENT,
+    COST_DISPATCH,
+    COST_OM_FIX,
+    COST_UPFRONT
 )
 
 r"""
@@ -65,13 +72,13 @@ def evaluate_dict(dict_values, results_main, results_meta):
                 KPI_COST_MATRIX: pd.DataFrame(
                     columns=[
                         LABEL,
-                        "costs_total",
-                        "costs_om",
-                        "costs_investment",
-                        "costs_upfront",
-                        "costs_price_dispatch",
-                        "costs_cost_om",
-                        "annuity_total",
+                        COST_TOTAL,
+                        COST_OM_TOTAL,
+                        COST_INVESTMENT,
+                        COST_UPFRONT,
+                        COST_DISPATCH,
+                        COST_OM_FIX,
+                        ANNUITY_TOTAL,
                         ANNUITY_OM,
                     ]
                 ),

--- a/src/E0_evaluation.py
+++ b/src/E0_evaluation.py
@@ -36,7 +36,7 @@ from src.constants_json_strings import (
     COST_INVESTMENT,
     COST_DISPATCH,
     COST_OM_FIX,
-    COST_UPFRONT
+    COST_UPFRONT,
 )
 
 r"""

--- a/src/E2_economics.py
+++ b/src/E2_economics.py
@@ -17,6 +17,13 @@ from src.constants_json_strings import (
     ANNUAL_TOTAL_FLOW,
     OPTIMIZED_ADD_CAP,
     ANNUITY_OM,
+    ANNUITY_TOTAL,
+    COST_TOTAL,
+    COST_OM_TOTAL,
+    COST_INVESTMENT,
+    COST_DISPATCH,
+    COST_OM_FIX,
+    COST_UPFRONT
 )
 
 r"""
@@ -69,7 +76,7 @@ def get_costs(dict_asset, economic_data):
                 + dict_asset[COST_DEVELOPMENT][VALUE]
             )
             costs_total = add_costs_and_total(
-                dict_asset, "costs_investment", costs_investment, costs_total
+                dict_asset, COST_INVESTMENT, costs_investment, costs_total
             )
 
         if (
@@ -86,7 +93,7 @@ def get_costs(dict_asset, economic_data):
                 + dict_asset[COST_DEVELOPMENT][VALUE]
             )
             costs_total = add_costs_and_total(
-                dict_asset, "costs_upfront", costs_upfront, costs_total
+                dict_asset, COST_UPFRONT, costs_upfront, costs_total
             )
 
         if (
@@ -98,10 +105,10 @@ def get_costs(dict_asset, economic_data):
                 * dict_asset[ANNUAL_TOTAL_FLOW][VALUE]
             )
             costs_total = add_costs_and_total(
-                dict_asset, "costs_price_dispatch", costs_price_dispatch, costs_total
+                dict_asset, COST_DISPATCH, costs_price_dispatch, costs_total
             )
             cost_om = add_costs_and_total(
-                dict_asset, "costs_price_dispatch", costs_price_dispatch, cost_om
+                dict_asset, COST_DISPATCH, costs_price_dispatch, cost_om
             )
 
         # todo actually, price is probably not the label, but price_dispatch
@@ -131,27 +138,27 @@ def get_costs(dict_asset, economic_data):
 
             costs_cost_om = dict_asset[LIFETIME_SPECIFIC_COST_OM][VALUE] * cap
             costs_total = add_costs_and_total(
-                dict_asset, "costs_cost_om", costs_cost_om, costs_total
+                dict_asset, COST_OM_FIX, costs_cost_om, costs_total
             )
             cost_om = add_costs_and_total(
-                dict_asset, "costs_cost_om", costs_cost_om, cost_om
+                dict_asset, COST_OM_FIX, costs_cost_om, cost_om
             )
 
         dict_asset.update(
             {
-                "costs_total": {VALUE: costs_total, UNIT: CURR},
-                "costs_om": {VALUE: cost_om, UNIT: CURR},
+                COST_TOTAL: {VALUE: costs_total, UNIT: CURR},
+                COST_OM_TOTAL: {VALUE: cost_om, UNIT: CURR},
             }
         )
 
         dict_asset.update(
             {
-                "annuity_total": {
-                    VALUE: dict_asset["costs_total"][VALUE] * economic_data[CRF][VALUE],
+                ANNUITY_TOTAL: {
+                    VALUE: dict_asset[COST_TOTAL][VALUE] * economic_data[CRF][VALUE],
                     UNIT: "currency/year",
                 },
                 ANNUITY_OM: {
-                    VALUE: dict_asset["costs_om"][VALUE] * economic_data[CRF][VALUE],
+                    VALUE: dict_asset[COST_OM_TOTAL][VALUE] * economic_data[CRF][VALUE],
                     UNIT: "currency/year",
                 },
             }

--- a/src/E2_economics.py
+++ b/src/E2_economics.py
@@ -23,7 +23,7 @@ from src.constants_json_strings import (
     COST_INVESTMENT,
     COST_DISPATCH,
     COST_OM_FIX,
-    COST_UPFRONT
+    COST_UPFRONT,
 )
 
 r"""

--- a/src/F0_output.py
+++ b/src/F0_output.py
@@ -17,7 +17,15 @@ from src.constants import (
     SECTORS,
     PATH_OUTPUT_FOLDER,
 )
-from src.constants_json_strings import OPTIMIZED_ADD_CAP, KPI, LABEL, KPI_SCALAR_MATRIX, COST_OM_TOTAL, COST_INVESTMENT, ANNUITY_TOTAL
+from src.constants_json_strings import (
+    OPTIMIZED_ADD_CAP,
+    KPI,
+    LABEL,
+    KPI_SCALAR_MATRIX,
+    COST_OM_TOTAL,
+    COST_INVESTMENT,
+    ANNUITY_TOTAL,
+)
 
 r"""
 Module F0 Output

--- a/src/F0_output.py
+++ b/src/F0_output.py
@@ -17,7 +17,7 @@ from src.constants import (
     SECTORS,
     PATH_OUTPUT_FOLDER,
 )
-from src.constants_json_strings import OPTIMIZED_ADD_CAP, KPI, LABEL, KPI_SCALAR_MATRIX
+from src.constants_json_strings import OPTIMIZED_ADD_CAP, KPI, LABEL, KPI_SCALAR_MATRIX, COST_OM_TOTAL, COST_INVESTMENT, ANNUITY_TOTAL
 
 r"""
 Module F0 Output
@@ -148,16 +148,16 @@ def plot_piecharts_of_costs(dict_values):
     """
 
     # Annuity costs plot (only plot if there are values with cost over 0)
-    F1_plots.evaluate_cost_parameter(dict_values, "annuity_total", "annuity")
+    F1_plots.evaluate_cost_parameter(dict_values, ANNUITY_TOTAL, "annuity")
 
     # First-investment costs plot (only plot if there are values with cost over 0)
     F1_plots.evaluate_cost_parameter(
-        dict_values, "costs_investment", "upfront_investment_costs"
+        dict_values, COST_INVESTMENT, "upfront_investment_costs"
     )
 
     # O&M costs plot (only plot if there are values with cost over 0)
     F1_plots.evaluate_cost_parameter(
-        dict_values, "costs_om", "operation_and_maintenance_costs"
+        dict_values, COST_OM_TOTAL, "operation_and_maintenance_costs"
     )
     return
 

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -60,7 +60,11 @@ from src.constants_json_strings import (
     COST_INVESTMENT,
     COST_DISPATCH,
     COST_OM_FIX,
-    COST_UPFRONT
+    COST_UPFRONT,
+    PROJECT_NAME,
+    PROJECT_ID,
+    SCENARIO_NAME,
+    SCENARIO_ID
 )
 
 OUTPUT_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER)
@@ -169,8 +173,8 @@ def create_app(results_json):
         list(dict_simsettings.items()), columns=["Setting", "Value"]
     )
 
-    projectName = "Harbor Norway"
-    scenarioName = "100% self-generation"
+    projectName = results_json[PROJECT_DATA][PROJECT_NAME] + "(ID:" + str(results_json[PROJECT_DATA][PROJECT_ID]) + ")"
+    scenarioName = results_json[PROJECT_DATA][SCENARIO_NAME] + "(ID:" + str(results_json[PROJECT_DATA][SCENARIO_ID]) + ")"
 
     releaseDesign = "0.0x"
 

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -55,6 +55,12 @@ from src.constants_json_strings import (
     KPI,
     KPI_SCALAR_MATRIX,
     KPI_COST_MATRIX,
+    COST_TOTAL,
+    COST_OM_TOTAL,
+    COST_INVESTMENT,
+    COST_DISPATCH,
+    COST_OM_FIX,
+    COST_UPFRONT
 )
 
 OUTPUT_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER)
@@ -308,10 +314,10 @@ def create_app(results_json):
     df_cost_matrix = df_cost_matrix.drop(
         [
             "index",
-            "costs_om",
-            "costs_investment",
-            "costs_price_dispatch",
-            "costs_cost_om",
+            COST_OM_TOTAL,
+            COST_INVESTMENT,
+            COST_DISPATCH,
+            COST_OM_FIX,
         ],
         axis=1,
     )
@@ -320,8 +326,8 @@ def create_app(results_json):
     df_cost_matrix = df_cost_matrix.rename(
         columns={
             LABEL: "Component",
-            "costs_total": "CAP",
-            "costs_upfront": "Upfront Investment Costs",
+            COST_TOTAL: "CAP",
+            COST_UPFRONT: "Upfront Investment Costs",
         }
     )
 

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -64,7 +64,7 @@ from src.constants_json_strings import (
     PROJECT_NAME,
     PROJECT_ID,
     SCENARIO_NAME,
-    SCENARIO_ID
+    SCENARIO_ID,
 )
 
 OUTPUT_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER)
@@ -173,8 +173,18 @@ def create_app(results_json):
         list(dict_simsettings.items()), columns=["Setting", "Value"]
     )
 
-    projectName = results_json[PROJECT_DATA][PROJECT_NAME] + "(ID:" + str(results_json[PROJECT_DATA][PROJECT_ID]) + ")"
-    scenarioName = results_json[PROJECT_DATA][SCENARIO_NAME] + "(ID:" + str(results_json[PROJECT_DATA][SCENARIO_ID]) + ")"
+    projectName = (
+        results_json[PROJECT_DATA][PROJECT_NAME]
+        + "(ID:"
+        + str(results_json[PROJECT_DATA][PROJECT_ID])
+        + ")"
+    )
+    scenarioName = (
+        results_json[PROJECT_DATA][SCENARIO_NAME]
+        + "(ID:"
+        + str(results_json[PROJECT_DATA][SCENARIO_ID])
+        + ")"
+    )
 
     releaseDesign = "0.0x"
 
@@ -316,14 +326,7 @@ def create_app(results_json):
 
     # Drop some irrelevant columns from the dataframe
     df_cost_matrix = df_cost_matrix.drop(
-        [
-            "index",
-            COST_OM_TOTAL,
-            COST_INVESTMENT,
-            COST_DISPATCH,
-            COST_OM_FIX,
-        ],
-        axis=1,
+        ["index", COST_OM_TOTAL, COST_INVESTMENT, COST_DISPATCH, COST_OM_FIX,], axis=1,
     )
 
     # Rename some of the column names

--- a/src/constants_json_strings.py
+++ b/src/constants_json_strings.py
@@ -122,7 +122,9 @@ CRF = "CRF"
 LIFETIME_SPECIFIC_COST_OM = "lifetime_specific_cost_om"
 LIFETIME_PRICE_DISPATCH = "lifetime_price_dispatch"
 LIFETIME_SPECIFIC_COST = "lifetime_specific_cost"
-ANNUITY_SPECIFIC_INVESTMENT_AND_OM = "annuity_of_specific_investment_costs_and_specific_annual_om"
+ANNUITY_SPECIFIC_INVESTMENT_AND_OM = (
+    "annuity_of_specific_investment_costs_and_specific_annual_om"
+)
 SIMULATION_ANNUITY = "simulation_annuity"
 
 # Other Parameters
@@ -158,8 +160,10 @@ ANNUITY_TOTAL = "annuity_total"
 # Costs - Total per asset
 COST_TOTAL = "costs_total"
 COST_OM_TOTAL = "costs_om_total"
-COST_OM_FIX = "costs_cost_om" # Fix asset operation/management costs per year, not depending on use
-COST_DISPATCH = "costs_dispatch" # Variable asset operation/management costs, depending on dispatch
+COST_OM_FIX = "costs_cost_om"  # Fix asset operation/management costs per year, not depending on use
+COST_DISPATCH = (
+    "costs_dispatch"  # Variable asset operation/management costs, depending on dispatch
+)
 COST_UPFRONT = "costs_upfront_in_year_zero"
 COST_INVESTMENT = "costs_investment_over_lifetime"
 

--- a/src/constants_json_strings.py
+++ b/src/constants_json_strings.py
@@ -116,13 +116,14 @@ TIMESERIES_PEAK = "timeseries_peak"
 
 # Pre-processing cost parameters
 ANNUITY_FACTOR = "annuity_factor"
-SIMULATION_ANNUITY = "simulation_annuity"
 CRF = "CRF"
 
 # Processed cost parameters
 LIFETIME_SPECIFIC_COST_OM = "lifetime_specific_cost_om"
 LIFETIME_PRICE_DISPATCH = "lifetime_price_dispatch"
 LIFETIME_SPECIFIC_COST = "lifetime_specific_cost"
+ANNUITY_SPECIFIC_INVESTMENT_AND_OM = "annuity_of_specific_investment_costs_and_specific_annual_om"
+SIMULATION_ANNUITY = "simulation_annuity"
 
 # Other Parameters
 SECTORS = "sectors"
@@ -152,21 +153,24 @@ OPTIMIZED_ADD_CAP = "optimizedAddCap"
 
 # Costs - Annuities
 ANNUITY_OM = "annuity_om"
-ANNUITY_CAPEX_OPEX_VAR = "annuity_capex_price_dispatch"
+ANNUITY_TOTAL = "annuity_total"
 
-# Costs - Total
+# Costs - Total per asset
 COST_TOTAL = "costs_total"
-COST_OM = "costs_om"
-COST_INVESTMENT = "costs_investment"
+COST_OM_TOTAL = "costs_om_total"
+COST_OM_FIX = "costs_cost_om" # Fix asset operation/management costs per year, not depending on use
+COST_DISPATCH = "costs_dispatch" # Variable asset operation/management costs, depending on dispatch
+COST_UPFRONT = "costs_upfront_in_year_zero"
+COST_INVESTMENT = "costs_investment_over_lifetime"
 
 # KPI_FLOW_MATRIX
 KPI_SCALARS = (
     ANNUITY_OM,
-    "annuity_total",
+    ANNUITY_TOTAL,
     COST_INVESTMENT,
-    COST_OM,
-    "costs_cost_om",
-    "costs_price_dispatch",
+    COST_OM_TOTAL,
+    COST_OM_FIX,
+    COST_DISPATCH,
     COST_TOTAL,
-    "costs_upfront",
+    COST_UPFRONT,
 )

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -27,7 +27,7 @@ from src.constants_json_strings import (
     SIMULATION_ANNUITY,
     LIFETIME_SPECIFIC_COST,
     CRF,
-    ANNUITY_CAPEX_OPEX_VAR,
+    ANNUITY_SPECIFIC_INVESTMENT_AND_OM,
     LIFETIME_SPECIFIC_COST_OM,
     LIFETIME_PRICE_DISPATCH,
     PERIODS,
@@ -98,11 +98,11 @@ dict_asset = {
 def test_evaluate_lifetime_costs_adds_all_parameters():
     C0.evaluate_lifetime_costs(settings, economic_data, dict_asset)
     for k in (
-        LIFETIME_SPECIFIC_COST,
-        ANNUITY_CAPEX_OPEX_VAR,
-        LIFETIME_SPECIFIC_COST_OM,
-        LIFETIME_PRICE_DISPATCH,
-        SIMULATION_ANNUITY,
+            LIFETIME_SPECIFIC_COST,
+            ANNUITY_SPECIFIC_INVESTMENT_AND_OM,
+            LIFETIME_SPECIFIC_COST_OM,
+            LIFETIME_PRICE_DISPATCH,
+            SIMULATION_ANNUITY,
     ):
         assert k in dict_asset.keys()
 

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -98,11 +98,11 @@ dict_asset = {
 def test_evaluate_lifetime_costs_adds_all_parameters():
     C0.evaluate_lifetime_costs(settings, economic_data, dict_asset)
     for k in (
-            LIFETIME_SPECIFIC_COST,
-            ANNUITY_SPECIFIC_INVESTMENT_AND_OM,
-            LIFETIME_SPECIFIC_COST_OM,
-            LIFETIME_PRICE_DISPATCH,
-            SIMULATION_ANNUITY,
+        LIFETIME_SPECIFIC_COST,
+        ANNUITY_SPECIFIC_INVESTMENT_AND_OM,
+        LIFETIME_SPECIFIC_COST_OM,
+        LIFETIME_PRICE_DISPATCH,
+        SIMULATION_ANNUITY,
     ):
         assert k in dict_asset.keys()
 

--- a/tests/test_E2_economics.py
+++ b/tests/test_E2_economics.py
@@ -15,6 +15,11 @@ from src.constants_json_strings import (
     ANNUAL_TOTAL_FLOW,
     OPTIMIZED_ADD_CAP,
     ANNUITY_OM,
+    ANNUITY_TOTAL,
+    COST_TOTAL,
+    COST_OM_TOTAL,
+    COST_DISPATCH,
+    COST_OM_FIX
 )
 
 dict_asset = {
@@ -39,12 +44,12 @@ def test_all_cost_info_parameters_added_to_dict_asset():
     """Tests whether the function get_costs is adding all the calculated costs to dict_asset."""
     E2.get_costs(dict_asset, dict_economic)
     for k in (
-        "costs_price_dispatch",
-        "costs_cost_om",
-        "costs_total",
-        "costs_om",
-        "annuity_total",
-        ANNUITY_OM,
+            COST_DISPATCH,
+            COST_OM_FIX,
+            COST_TOTAL,
+            COST_OM_TOTAL,
+            ANNUITY_TOTAL,
+            ANNUITY_OM,
     ):
         assert k in dict_asset
 

--- a/tests/test_E2_economics.py
+++ b/tests/test_E2_economics.py
@@ -19,7 +19,7 @@ from src.constants_json_strings import (
     COST_TOTAL,
     COST_OM_TOTAL,
     COST_DISPATCH,
-    COST_OM_FIX
+    COST_OM_FIX,
 )
 
 dict_asset = {
@@ -44,12 +44,12 @@ def test_all_cost_info_parameters_added_to_dict_asset():
     """Tests whether the function get_costs is adding all the calculated costs to dict_asset."""
     E2.get_costs(dict_asset, dict_economic)
     for k in (
-            COST_DISPATCH,
-            COST_OM_FIX,
-            COST_TOTAL,
-            COST_OM_TOTAL,
-            ANNUITY_TOTAL,
-            ANNUITY_OM,
+        COST_DISPATCH,
+        COST_OM_FIX,
+        COST_TOTAL,
+        COST_OM_TOTAL,
+        ANNUITY_TOTAL,
+        ANNUITY_OM,
     ):
         assert k in dict_asset
 


### PR DESCRIPTION
Fix #348 

**Changes proposed in this pull request**:
-  Change into constants into "constants_json_strings.py": "annuity_total", "costs_opex_fix"/"costs_cost_om", "costs_opex_var"/"costs_p_dispatch", "costs_upfront", "costs_total" and "costs_om"

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
