### PR TITLE
Fix/fixcost csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Here is a template for new release sections
 
 ### Removed
 
+### Fix
+- Deleted columns from ´fixcost.csv´ as this is currently not used (#362)
+
 ## [0.3.0] - 2020-06-08
 
 ### Added

--- a/inputs/csv_elements/fixcost.csv
+++ b/inputs/csv_elements/fixcost.csv
@@ -1,8 +1,8 @@
-,unit,distribution_grid,engineering,operation
-age_installed,year,10, 0, 0
-development_costs,currency,0.0,0,0
-specific_costs,currency,0.0,0,0
-label,str,distribution grid infrastructure,"R&D, engineering",Fix project operation
-lifetime,year,30,20,20
-specific_costs_om,currency/year,0,0,4600
-dispatch_price,currency/kWh,0,0,0
+,unit
+age_installed,year
+development_costs,currency
+specific_costs,currency
+label,str
+lifetime,year
+specific_costs_om,currency/year
+dispatch_price,currency/kWh


### PR DESCRIPTION
Very small fix, removing columns from `fixcost.csv` as this info is not processed currently.