### PR TITLE
Do not copy timeseries files twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Here is a template for new release sections
 ### Fixed
 - Deleted columns from ´fixcost.csv´ as this is currently not used (#362)
 - Issue #357 Bug connected to global variables (#356)
+- Issue #168 Duplicate of timeseries files (#388)
 
 ## [0.3.0] - 2020-06-08
 

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -1198,13 +1198,6 @@ def receive_timeseries_from_csv(
             is_demand_profile,
         )
 
-    # copy input files
-    shutil.copy(
-        file_path, os.path.join(settings[PATH_OUTPUT_FOLDER], INPUTS_COPY, file_name)
-    )
-    logging.debug("Copied timeseries %s to output folder / inputs.", file_path)
-    return
-
 
 def plot_input_timeseries(
     dict_values, user_input, timeseries, asset_name, column_head, is_demand_profile


### PR DESCRIPTION
Fix #168

**Changes proposed in this pull request**:
- Deleted code where the files were copied redundantly into the output folder

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
