### PR TITLE
Change relative folder path to absolute in tests files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Here is a template for new release sections
 ### Changed
 - Use selenium to print the automatic project report, `python mvs_report.py -h` for help (#356)
 - Sorted parameters in csv´s withing the input folder (#374)
+- Change relative folder path to absolute in tests files (#396)
 
 ### Removed
 

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -28,9 +28,9 @@ PARSER = initializing.create_parser()
 
 class TestProcessUserArguments:
 
-    test_in_path = os.path.join("tests", "inputs")
-    test_out_path = os.path.join(".", "tests", "MVS_outputs")
-    fake_input_path = os.path.join("tests", "fake_inputs")
+    test_in_path = os.path.join(TEST_REPO_PATH, "inputs")
+    test_out_path = os.path.join(TEST_REPO_PATH, "MVS_outputs")
+    fake_input_path = os.path.join(TEST_REPO_PATH, "fake_inputs")
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -17,6 +17,7 @@ from .constants import (
     PATH_INPUT_FOLDER,
     PATH_OUTPUT_FOLDER,
     PATH_OUTPUT_FOLDER_INPUTS,
+    TEST_REPO_PATH,
 )
 
 
@@ -38,8 +39,8 @@ PARSER = initializing.create_parser()
 
 class TestTemporaryJsonFileDisposal:
 
-    test_in_path = os.path.join("tests", "inputs")
-    test_out_path = os.path.join(".", "tests", "MVS_outputs")
+    test_in_path = os.path.join(TEST_REPO_PATH, "inputs")
+    test_out_path = os.path.join(TEST_REPO_PATH, "MVS_outputs")
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Some folder path were relative and it lead to errors on pytest with conda env on mac

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
