### PR TITLE
Storage name readability and MaximumCap in energyStorages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,11 @@ Here is a template for new release sections
 - Use pyppeteers instead of selenium to emulate the webbrowser and print the pdf report
  automatically (#407)
 - Update flowchart again (#409)
+- Label of storage components (storage capacity, input power, output power) will by default be redefined to the name of the storage and this component (#415)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)
+- `MaximumCap` from list of required parameters for `energyStorage` assets (#415)
 
 ### Fixed
 - Deleted columns from ´fixcost.csv´ as this is currently not used (#362)

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -305,6 +305,7 @@ def energyStorage(dict_values, group):
     """
     for asset in dict_values[group]:
         for subasset in [STORAGE_CAPACITY, INPUT_POWER, OUTPUT_POWER]:
+            # Redefining the label of storage components, ie. so that is is clear to which storage a component (eg. input power) belongs.
             dict_values[group][asset][subasset].update({LABEL: dict_values[group][asset][LABEL]+ "_"+dict_values[group][asset][subasset][LABEL]})
             define_missing_cost_data(
                 dict_values, dict_values[group][asset][subasset],

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -305,6 +305,7 @@ def energyStorage(dict_values, group):
     """
     for asset in dict_values[group]:
         for subasset in [STORAGE_CAPACITY, INPUT_POWER, OUTPUT_POWER]:
+            dict_values[group][asset][subasset].update({LABEL: dict_values[group][asset][LABEL]+ "_"+dict_values[group][asset][subasset][LABEL]})
             define_missing_cost_data(
                 dict_values, dict_values[group][asset][subasset],
             )

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -306,7 +306,13 @@ def energyStorage(dict_values, group):
     for asset in dict_values[group]:
         for subasset in [STORAGE_CAPACITY, INPUT_POWER, OUTPUT_POWER]:
             # Redefining the label of storage components, ie. so that is is clear to which storage a component (eg. input power) belongs.
-            dict_values[group][asset][subasset].update({LABEL: dict_values[group][asset][LABEL]+ "_"+dict_values[group][asset][subasset][LABEL]})
+            dict_values[group][asset][subasset].update(
+                {
+                    LABEL: dict_values[group][asset][LABEL]
+                    + "_"
+                    + dict_values[group][asset][subasset][LABEL]
+                }
+            )
             define_missing_cost_data(
                 dict_values, dict_values[group][asset][subasset],
             )

--- a/src/constants.py
+++ b/src/constants.py
@@ -181,10 +181,7 @@ EXTRA_CSV_PARAMETERS = {
     MAXIMUM_CAP: {
         DEFAULT_VALUE: None,
         WARNING_TEXT: "allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). ",
-        REQUIRED_IN_CSV_ELEMENTS: [
-            ENERGY_CONVERSION,
-            ENERGY_PRODUCTION
-        ],
+        REQUIRED_IN_CSV_ELEMENTS: [ENERGY_CONVERSION, ENERGY_PRODUCTION],
     },
     RENEWABLE_ASSET_BOOL: {
         DEFAULT_VALUE: False,

--- a/src/constants.py
+++ b/src/constants.py
@@ -183,8 +183,7 @@ EXTRA_CSV_PARAMETERS = {
         WARNING_TEXT: "allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). ",
         REQUIRED_IN_CSV_ELEMENTS: [
             ENERGY_CONVERSION,
-            ENERGY_STORAGE,
-            ENERGY_PRODUCTION,
+            ENERGY_PRODUCTION
         ],
     },
     RENEWABLE_ASSET_BOOL: {


### PR DESCRIPTION
Fix #273
Adresses #413 

**Changes proposed in this pull request**:
- The label of storages will - as a general rule - be redefined as `storage label + subasset name` (#273)
- `MaximumCap` is removed from list of required parameters of `energyStorage` (#413)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
