### PR TITLE
add a section to the autoreport to display logging messages like warnings and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Here is a template for new release sections
  - Tests for source components in D1 (#391)
  - Option `-i` for `python mvs_report.py`, `python mvs_report.py -h` for help (#407)
  - Pyppeteer package for OS X users in troubleshooting (#414)
+ - Add an enhancement to the auto-report by printing the log messages such as warnings and errors (#417)
 
 ### Changed
 - Use selenium to print the automatic project report, `python mvs_report.py -h` for help (#356)

--- a/report/assets/styles.css
+++ b/report/assets/styles.css
@@ -60,15 +60,18 @@ h4 {
    text-align: left;
    }
 
-
-
 @media screen {
 
     /* Styling for the E-lands logo and the title of the report */
     .header_title_logo {
         margin: 30px;
 }
-
+    /* Styling for the log messages */
+    .list-log {
+        text-align: left;
+        font-size: 20pt;
+        margin: 30px;
+}
     .tableplay {
         width:70%;
         font-size: 20pt;

--- a/report/assets/styles.css
+++ b/report/assets/styles.css
@@ -67,10 +67,9 @@ h4 {
         margin: 30px;
 }
     /* Styling for the log messages */
-    .list-log-screen {
+    .list-log {
         text-align: left;
         font-size: 20pt;
-        margin: 30px;
 }
     .tableplay {
         width:70%;
@@ -204,7 +203,7 @@ h4 {
     display: none;
   }
 
-  .list-log-print {
+  .print {
     display: none;
   }
 
@@ -222,11 +221,11 @@ h4 {
 
     }
 
-  .list-log-screen {
+  .no-print > div {
     display: none;
   }
 
-  .list-log-print {
+  .list-log{
     text-align: left;
     font-size: 15pt;
   }

--- a/report/assets/styles.css
+++ b/report/assets/styles.css
@@ -67,7 +67,7 @@ h4 {
         margin: 30px;
 }
     /* Styling for the log messages */
-    .list-log {
+    .list-log-screen {
         text-align: left;
         font-size: 20pt;
         margin: 30px;
@@ -204,9 +204,11 @@ h4 {
     display: none;
   }
 
+  .list-log-print {
+    display: none;
+  }
+
 }
-
-
 
 /* print styles */
 @media print {
@@ -219,6 +221,15 @@ h4 {
   #location-map-div {
 
     }
+
+  .list-log-screen {
+    display: none;
+  }
+
+  .list-log-print {
+    text-align: left;
+    font-size: 15pt;
+  }
 
   .location-map-column {
     width: 48%;

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -217,21 +217,24 @@ def insert_image_array(img_list, width=500):
         ],
     )
 
-def insert_log_messages(log_dict, title_of_section):
+
+def insert_log_messages(log_dict):
     """
-    :param title_of_section: string, name of the sub-section
     :param log_dict: dict, containing the logging messages
     :return: html.Div() element
     """
     return html.Div(
-        className='log-messages-rep',
         children=[
-            html.H3(title_of_section), html.Hr(className="cell small-12 horizontal_line"),
-            html.Ul(children=[
-                html.Li(children=[html.Span(k), v])
-                for k, v in log_dict.items()
-            ])
-        ])
+            html.Ul(
+                children=[
+                    html.Li(
+                        className="grid-x small-10 list-log", children=[html.Span(v)]
+                    )
+                    for k, v in log_dict.items()
+                ]
+            )
+        ]
+    )
 
 
 # Styling of the report
@@ -319,16 +322,16 @@ def create_app(results_json):
     )
 
     projectName = (
-            results_json[PROJECT_DATA][PROJECT_NAME]
-            + "(ID:"
-            + str(results_json[PROJECT_DATA][PROJECT_ID])
-            + ")"
+        results_json[PROJECT_DATA][PROJECT_NAME]
+        + "(ID:"
+        + str(results_json[PROJECT_DATA][PROJECT_ID])
+        + ")"
     )
     scenarioName = (
-            results_json[PROJECT_DATA][SCENARIO_NAME]
-            + "(ID:"
-            + str(results_json[PROJECT_DATA][SCENARIO_ID])
-            + ")"
+        results_json[PROJECT_DATA][SCENARIO_NAME]
+        + "(ID:"
+        + str(results_json[PROJECT_DATA][SCENARIO_ID])
+        + ")"
     )
 
     releaseDesign = "0.0x"
@@ -476,7 +479,7 @@ def create_app(results_json):
 
     # Drop some irrelevant columns from the dataframe
     df_cost_matrix = df_cost_matrix.drop(
-        ["index", COST_OM_TOTAL, COST_INVESTMENT, COST_DISPATCH, COST_OM_FIX, ], axis=1,
+        ["index", COST_OM_TOTAL, COST_INVESTMENT, COST_DISPATCH, COST_OM_FIX,], axis=1,
     )
 
     # Rename some of the column names
@@ -496,22 +499,24 @@ def create_app(results_json):
     errors_dict = {}
 
     log_file = os.path.join(OUTPUT_FOLDER, "mvs_logfile.log")
-    words = ('WARNING', 'ERROR')
-    substrings = []
+    # log_file = "/home/mr/Projects/mvs_eland/MVS_outputs/mvs_logfile.log"
+    print(log_file)
 
     with open(log_file) as log_messages:
         log_messages = log_messages.readlines()
 
     i = 0
     for line in log_messages:
-        if 'WARNING' in line:
+        if "WARNING" in line:
             i = i + 1
-            substrings = line.split(' - ')
-            warnings_dict.update({i: substrings[-1]})
-        elif 'ERROR' in line:
+            substrings = line.split(" - ")
+            message_string = u'\u2022 '+substrings[-1]
+            warnings_dict.update({i: message_string})
+        elif "ERROR" in line:
             i = i + 1
-            substrings = line.split(' - ')
-            errors_dict.update({i: substrings[-1]})
+            substrings = line.split(" - ")
+            message_string = u'\u2022 ' + substrings[-1]
+            errors_dict.update({i: message_string})
 
     app.layout = html.Div(
         id="main-div",
@@ -730,8 +735,25 @@ def create_app(results_json):
                 ],
             ),
             html.Section(
-                insert_log_messages(log_dict=warnings_dict, title_of_section='Warning Messages'),
-                insert_log_messages(log_dict=errors_dict, title_of_section='Error Messages')
+                className="cell small-10 small_offset-1 grid-x",
+                children=[
+                    html.Div(
+                        className="cell",
+                        children=[insert_headings(heading_text="Logging Messages"),],
+                    ),
+                    html.Div(
+                        children=[
+                            insert_subsection(
+                                title="Warning Messages",
+                                content=insert_log_messages(log_dict=warnings_dict),
+                            ),
+                            insert_subsection(
+                                title="Error Messages",
+                                content=insert_log_messages(log_dict=errors_dict),
+                            ),
+                        ]
+                    ),
+                ],
             ),
         ],
     )

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -225,6 +225,7 @@ def insert_log_messages(log_dict):
     """
     return html.Div(
         children=[
+            # this will be displayed only in the app
             html.Div(
                 className="grid-x no-print",
                 children=[
@@ -238,13 +239,12 @@ def insert_log_messages(log_dict):
                     for k, v in log_dict.items()
                 ],
             ),
+            # this will be displayed only in the printed version
             html.Div(
                 className="list-log print",
-                children=[
-                    html.Ul(children=[html.Span(v)]) for k, v in log_dict.items()
-                ],
+                children=html.Ul(children=[html.Li(v) for k, v in log_dict.items()]),
             ),
-        ]
+        ],
     )
 
 

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -239,6 +239,7 @@ def insert_log_messages(log_dict):
 
 # Styling of the report
 
+
 def create_app(results_json):
     # Initialize the app
 
@@ -510,12 +511,12 @@ def create_app(results_json):
         if "WARNING" in line:
             i = i + 1
             substrings = line.split(" - ")
-            message_string = u'\u2022 '+substrings[-1]
+            message_string = "\u2022 " + substrings[-1]
             warnings_dict.update({i: message_string})
         elif "ERROR" in line:
             i = i + 1
             substrings = line.split(" - ")
-            message_string = u'\u2022 ' + substrings[-1]
+            message_string = "\u2022 " + substrings[-1]
             errors_dict.update({i: message_string})
 
     app.layout = html.Div(

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -319,16 +319,16 @@ def create_app(results_json):
     )
 
     projectName = (
-        results_json[PROJECT_DATA][PROJECT_NAME]
-        + "(ID:"
-        + str(results_json[PROJECT_DATA][PROJECT_ID])
-        + ")"
+            results_json[PROJECT_DATA][PROJECT_NAME]
+            + "(ID:"
+            + str(results_json[PROJECT_DATA][PROJECT_ID])
+            + ")"
     )
     scenarioName = (
-        results_json[PROJECT_DATA][SCENARIO_NAME]
-        + "(ID:"
-        + str(results_json[PROJECT_DATA][SCENARIO_ID])
-        + ")"
+            results_json[PROJECT_DATA][SCENARIO_NAME]
+            + "(ID:"
+            + str(results_json[PROJECT_DATA][SCENARIO_ID])
+            + ")"
     )
 
     releaseDesign = "0.0x"
@@ -476,7 +476,7 @@ def create_app(results_json):
 
     # Drop some irrelevant columns from the dataframe
     df_cost_matrix = df_cost_matrix.drop(
-        ["index", COST_OM_TOTAL, COST_INVESTMENT, COST_DISPATCH, COST_OM_FIX,], axis=1,
+        ["index", COST_OM_TOTAL, COST_INVESTMENT, COST_DISPATCH, COST_OM_FIX, ], axis=1,
     )
 
     # Rename some of the column names

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -217,9 +217,24 @@ def insert_image_array(img_list, width=500):
         ],
     )
 
+def insert_log_messages(log_dict, title_of_section):
+    """
+    :param title_of_section: string, name of the sub-section
+    :param log_dict: dict, containing the logging messages
+    :return: html.Div() element
+    """
+    return html.Div(
+        className='log-messages-rep',
+        children=[
+            html.H3(title_of_section), html.Hr(className="cell small-12 horizontal_line"),
+            html.Ul(children=[
+                html.Li(children=[html.Span(k), v])
+                for k, v in log_dict.items()
+            ])
+        ])
+
 
 # Styling of the report
-
 
 def create_app(results_json):
     # Initialize the app

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -225,7 +225,8 @@ def insert_log_messages(log_dict):
     """
     return html.Div(
         children=[
-            html.Ul(
+            html.Div(
+                className="grid-x no-print",
                 children=[
                     html.Div(
                         className="cell grid-x",
@@ -235,8 +236,14 @@ def insert_log_messages(log_dict):
                         ],
                     )
                     for k, v in log_dict.items()
-                ]
-            )
+                ],
+            ),
+            html.Div(
+                className="list-log print",
+                children=[
+                    html.Ul(children=[html.Span(v)]) for k, v in log_dict.items()
+                ],
+            ),
         ]
     )
 

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -491,6 +491,28 @@ def create_app(results_json):
     # Round the numeric values to two significant digits
     df_cost_matrix = df_cost_matrix.round(2)
 
+    # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
+    warnings_dict = {}
+    errors_dict = {}
+
+    log_file = os.path.join(OUTPUT_FOLDER, "mvs_logfile.log")
+    words = ('WARNING', 'ERROR')
+    substrings = []
+
+    with open(log_file) as log_messages:
+        log_messages = log_messages.readlines()
+
+    i = 0
+    for line in log_messages:
+        if 'WARNING' in line:
+            i = i + 1
+            substrings = line.split(' - ')
+            warnings_dict.update({i: substrings[-1]})
+        elif 'ERROR' in line:
+            i = i + 1
+            substrings = line.split(' - ')
+            errors_dict.update({i: substrings[-1]})
+
     app.layout = html.Div(
         id="main-div",
         className="grid-x align-center",

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -227,8 +227,12 @@ def insert_log_messages(log_dict):
         children=[
             html.Ul(
                 children=[
-                    html.Li(
-                        className="grid-x small-10 list-log", children=[html.Span(v)]
+                    html.Div(
+                        className="cell grid-x",
+                        children=[
+                            html.Div(children=k, className="cell small-1 list-marker"),
+                            html.Div(children=v, className="cell small-11 list-log"),
+                        ],
                     )
                     for k, v in log_dict.items()
                 ]

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -522,12 +522,12 @@ def create_app(results_json):
         if "WARNING" in line:
             i = i + 1
             substrings = line.split(" - ")
-            message_string = "\u2022 " + substrings[-1]
+            message_string = substrings[-1]
             warnings_dict.update({i: message_string})
         elif "ERROR" in line:
             i = i + 1
             substrings = line.split(" - ")
-            message_string = "\u2022 " + substrings[-1]
+            message_string = substrings[-1]
             errors_dict.update({i: message_string})
 
     app.layout = html.Div(

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -729,6 +729,10 @@ def create_app(results_json):
                     ),
                 ],
             ),
+            html.Section(
+                insert_log_messages(log_dict=warnings_dict, title_of_section='Warning Messages'),
+                insert_log_messages(log_dict=errors_dict, title_of_section='Error Messages')
+            ),
         ],
     )
     return app

--- a/tests/inputs/csv_elements/energyConsumption.csv
+++ b/tests/inputs/csv_elements/energyConsumption.csv
@@ -2,7 +2,7 @@
 label,str,Harbor,Remaining demand,Shore power (docked ships)
 unit,str,kW,kW,kW
 inflow_direction,str,Electricity,Electricity,Electricity
-file_name,str,demand_habor.csv,demand_remaining.csv,demand_shore_power.csv
+file_name,str,demand_harbor.csv,demand_remaining.csv,demand_shore_power.csv
 energyVector,str,Electricity,Electricity,Electricity
 type_oemof,str,sink,sink,sink
 type_asset,str,demand,demand,demand

--- a/tests/inputs/csv_elements/simulation_settings.csv
+++ b/tests/inputs/csv_elements/simulation_settings.csv
@@ -1,7 +1,7 @@
 ,unit,simulation_settings
 label,str,simulation_settings
 start_date,str,2018-01-01 00:00:00
-evaluated_period,days,2
+evaluated_period,days,365
 timestep,minutes,60
 output_lp_file,bool,False
 restore_from_oemof_file,bool,True


### PR DESCRIPTION
Fix #390

**Changes proposed in this pull request**:
- Add functions and HTML components to display logging messages in the web app and PDF of the autoreport

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
