### PR TITLE
Version number is only editable in one module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_install:
 
 # command to install dependencies
 install:
-  - pip install -e .
   - pip install -r requirements.txt
   - pip install -r tests/test_requirements.txt
+  - pip install -e .
 
 # commands to run tests 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Here is a template for new release sections
  automatically (#407)
 - Update flowchart again (#409)
 - Label of storage components (storage capacity, input power, output power) will by default be redefined to the name of the storage and this component (#415)
+- Version number and date is only to be edited in one file (#419)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)

--- a/mvs_eland_tool/__init__.py
+++ b/mvs_eland_tool/__init__.py
@@ -1,6 +1,2 @@
-version = "0.3.0"  # update_me Versioning scheme: Major release.Minor release.Patches
-version_date = "2020-06-08"  # update_me Update date
-
-
 from mvs_eland_tool.local_deploy import main as main
 from mvs_eland_tool.server_deploy import main as run_simulation

--- a/mvs_eland_tool/local_deploy.py
+++ b/mvs_eland_tool/local_deploy.py
@@ -37,7 +37,7 @@ import src.C0_data_processing as data_processing
 import src.D0_modelling_and_optimization as modelling
 import src.E0_evaluation as evaluation
 import src.F0_output as output_processing
-from mvs_eland_tool import version, version_date
+from mvs_eland_tool.version import version_num, version_date
 from src.constants import (
     CSV_ELEMENTS,
     CSV_EXT,
@@ -84,7 +84,7 @@ def main(**kwargs):
 
     welcome_text = (
         "\n \n Multi-Vector Simulation Tool (MVS) V"
-        + version
+        + version_num
         + " "
         + "\n Version: "
         + version_date

--- a/mvs_eland_tool/server_deploy.py
+++ b/mvs_eland_tool/server_deploy.py
@@ -41,7 +41,7 @@ import src.C0_data_processing as data_processing
 import src.D0_modelling_and_optimization as modelling
 import src.E0_evaluation as evaluation
 import src.F0_output as output_processing
-from mvs_eland_tool import version, version_date
+from mvs_eland_tool.version import version_num, version_date
 
 
 def main(json_dict, **kwargs):
@@ -68,7 +68,7 @@ def main(json_dict, **kwargs):
 
     welcome_text = (
         "\n \n Multi-Vector Simulation Tool (MVS) V"
-        + version
+        + version_num
         + " "
         + "\n Version: "
         + version_date

--- a/mvs_eland_tool/version.py
+++ b/mvs_eland_tool/version.py
@@ -1,0 +1,4 @@
+version_num = (
+    "0.3.0"  # update_me Versioning scheme: Major release.Minor release.Patches
+)
+version_date = "2020-06-08"  # update_me Update date

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ https://github.com/pypa/sampleproject
 from setuptools import setup, find_packages
 from os import path
 
+from mvs_eland_tool.version import version_num
+
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
@@ -38,7 +40,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.3.0",  # Required
+    version=version_num,  # Required
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -74,8 +74,7 @@ from src.constants_json_strings import (
 )
 
 # TODO link this to the version and date number @Bachibouzouk
-version = "X.Y.Z"
-version_date = "YYYY-MM-DD"
+from mvs_eland_tool.version import version_num, version_date
 
 OUTPUT_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER)
 CSV_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER, INPUTS_COPY, CSV_ELEMENTS)
@@ -499,7 +498,7 @@ def create_app(results_json):
                     html.Div(
                         className="cell imp_info",
                         children=[
-                            html.P(f"MVS Release: {version} ({version_date})"),
+                            html.P(f"MVS Release: {version_num} ({version_date})"),
                             html.P(f"Branch-id: {branchID}"),
                             html.P(f"Simulation date: {simDate}"),
                             html.Div(


### PR DESCRIPTION
Fix #355 

**Changes proposed in this pull request**:
- Create a module (`mvs_eland_tool/version.py`) to store the version number and date

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
