### PR TITLE
Improve logging messages of D1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Here is a template for new release sections
 - Label of storage components (storage capacity, input power, output power) will by default be redefined to the name of the storage and this component (#415)
 - Version number and date is only to be edited in one file (#419)
 - Add `ìnputs` folder to `.gitignore` (#401)
+- Adapt and add logging messages for components added to the model in D1 (#429)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -775,7 +775,7 @@ def sink_dispatchable(model, dict_asset, **kwargs):
     sink_dispatchable = solph.Sink(label=dict_asset[LABEL], inputs=inputs,)
     model.add(sink_dispatchable)
     kwargs["sinks"].update({dict_asset[LABEL]: sink_dispatchable})
-    logging.info("Added: Dispatchable sink %s", dict_asset[LABEL])
+    logging.debug("Added: Dispatchable sink %s", dict_asset[LABEL])
     return
 
 
@@ -810,5 +810,5 @@ def sink_non_dispatchable(model, dict_asset, **kwargs):
     sink_demand = solph.Sink(label=dict_asset[LABEL], inputs=inputs,)
     model.add(sink_demand)
     kwargs["sinks"].update({dict_asset[LABEL]: sink_demand})
-    logging.info("Added: Non-dispatchable sink %s", dict_asset[LABEL])
+    logging.debug("Added: Non-dispatchable sink %s", dict_asset[LABEL])
     return

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -679,9 +679,10 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     else:
         if TIMESERIES in dict_asset:
+            logging.info(
+                "Asset %s is introduced as a dispatchable source with an availability schedule.", dict_asset[LABEL])
             logging.debug(
-                "Change code in D1/source_dispatchable: timeseries_normalized not the only key determining the flow"
-            )
+                "The availability schedule is solely introduced because the key %s was not in the asset´s dictionary. \nIt should only be applied to DSO sources. If the asset should not have this behaviour, please create an issue.", TIMESERIES_NORMALIZED)
         outputs = {
             kwargs["busses"][dict_asset[OUTPUT_BUS_NAME]]: solph.Flow(
                 label=dict_asset[LABEL],
@@ -725,9 +726,12 @@ def source_dispatchable_fix(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     else:
         if TIMESERIES in dict_asset:
+            logging.info(
+                "Asset %s is introduced as a dispatchable source with an availability schedule.",
+                dict_asset[LABEL])
             logging.debug(
-                "Change code in D1/source_dispatchable: timeseries_normalized not the only key determining the flow"
-            )
+                "The availability schedule is solely introduced because the key %s was not in the asset´s dictionary. \nIt should only be applied to DSO sources. If the asset should not have this behaviour, please create an issue.",
+                TIMESERIES_NORMALIZED)
         outputs = {
             kwargs["busses"][dict_asset[OUTPUT_BUS_NAME]]: solph.Flow(
                 label=dict_asset[LABEL],

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -277,19 +277,21 @@ def check_optimize_cap(model, dict_asset, func_constant, func_optimize, **kwargs
     """
     if dict_asset[OPTIMIZE_CAP][VALUE] is False:
         func_constant(model, dict_asset, **kwargs)
-        logging.debug(
-            "Defined asset %s as %s (fix capacity)",
-            dict_asset[LABEL],
-            dict_asset["type_oemof"],
-        )
+        if dict_asset["type_oemof"] != "source":
+            logging.debug(
+                "Added: %s %s (fixed capacity)",
+                dict_asset["type_oemof"].capitalize(),
+                dict_asset[LABEL],
+            )
 
     elif dict_asset[OPTIMIZE_CAP][VALUE] is True:
         func_optimize(model, dict_asset, **kwargs)
-        logging.debug(
-            "Defined asset %s as %s (to be optimized)",
-            dict_asset[LABEL],
-            dict_asset["type_oemof"],
-        )
+        if dict_asset["type_oemof"] != "source":
+            logging.debug(
+                "Added: %s %s (capacity to be optimized)",
+                dict_asset["type_oemof"].capitalize(),
+                dict_asset[LABEL],
+            )
     else:
         raise ValueError(
             f"Input error! 'optimize_cap' of asset {dict_asset['label']}\n should be True/False but is {dict_asset['optimizeCap']['value']}."
@@ -613,6 +615,7 @@ def source_non_dispatchable_fix(model, dict_asset, **kwargs):
 
     model.add(source_non_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_non_dispatchable})
+    logging.debug("Added: Non-dispatchable source %s (fixed capacity)", dict_asset[LABEL])
     return
 
 
@@ -647,6 +650,7 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
 
     model.add(source_non_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_non_dispatchable})
+    logging.debug("Added: Non-dispatchable source %s (capacity to be optimized)", dict_asset[LABEL])
     return
 
 
@@ -687,7 +691,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     model.add(source_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_dispatchable})
-    logging.info("Added: Dispatchable source %s", dict_asset[LABEL])
+    logging.debug("Added: Dispatchable source %s (capacity to be optimized)", dict_asset[LABEL])
     return
 
 
@@ -727,7 +731,7 @@ def source_dispatchable_fix(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     model.add(source_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_dispatchable})
-    logging.info("Added: Dispatchable source %s", dict_asset[LABEL])
+    logging.debug("Added: Dispatchable source %s (fixed capacity)", dict_asset[LABEL])
     return
 
 

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -680,9 +680,13 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
     else:
         if TIMESERIES in dict_asset:
             logging.info(
-                "Asset %s is introduced as a dispatchable source with an availability schedule.", dict_asset[LABEL])
+                "Asset %s is introduced as a dispatchable source with an availability schedule.",
+                dict_asset[LABEL],
+            )
             logging.debug(
-                "The availability schedule is solely introduced because the key %s was not in the asset´s dictionary. \nIt should only be applied to DSO sources. If the asset should not have this behaviour, please create an issue.", TIMESERIES_NORMALIZED)
+                "The availability schedule is solely introduced because the key %s was not in the asset´s dictionary. \nIt should only be applied to DSO sources. If the asset should not have this behaviour, please create an issue.",
+                TIMESERIES_NORMALIZED,
+            )
         outputs = {
             kwargs["busses"][dict_asset[OUTPUT_BUS_NAME]]: solph.Flow(
                 label=dict_asset[LABEL],
@@ -728,10 +732,12 @@ def source_dispatchable_fix(model, dict_asset, **kwargs):
         if TIMESERIES in dict_asset:
             logging.info(
                 "Asset %s is introduced as a dispatchable source with an availability schedule.",
-                dict_asset[LABEL])
+                dict_asset[LABEL],
+            )
             logging.debug(
                 "The availability schedule is solely introduced because the key %s was not in the asset´s dictionary. \nIt should only be applied to DSO sources. If the asset should not have this behaviour, please create an issue.",
-                TIMESERIES_NORMALIZED)
+                TIMESERIES_NORMALIZED,
+            )
         outputs = {
             kwargs["busses"][dict_asset[OUTPUT_BUS_NAME]]: solph.Flow(
                 label=dict_asset[LABEL],

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -615,7 +615,9 @@ def source_non_dispatchable_fix(model, dict_asset, **kwargs):
 
     model.add(source_non_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_non_dispatchable})
-    logging.debug("Added: Non-dispatchable source %s (fixed capacity)", dict_asset[LABEL])
+    logging.debug(
+        "Added: Non-dispatchable source %s (fixed capacity)", dict_asset[LABEL]
+    )
     return
 
 
@@ -650,7 +652,10 @@ def source_non_dispatchable_optimize(model, dict_asset, **kwargs):
 
     model.add(source_non_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_non_dispatchable})
-    logging.debug("Added: Non-dispatchable source %s (capacity to be optimized)", dict_asset[LABEL])
+    logging.debug(
+        "Added: Non-dispatchable source %s (capacity to be optimized)",
+        dict_asset[LABEL],
+    )
     return
 
 
@@ -691,7 +696,9 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     model.add(source_dispatchable)
     kwargs["sources"].update({dict_asset[LABEL]: source_dispatchable})
-    logging.debug("Added: Dispatchable source %s (capacity to be optimized)", dict_asset[LABEL])
+    logging.debug(
+        "Added: Dispatchable source %s (capacity to be optimized)", dict_asset[LABEL]
+    )
     return
 
 

--- a/src/D1_model_components.py
+++ b/src/D1_model_components.py
@@ -674,7 +674,7 @@ def source_dispatchable_optimize(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     else:
         if TIMESERIES in dict_asset:
-            logging.error(
+            logging.debug(
                 "Change code in D1/source_dispatchable: timeseries_normalized not the only key determining the flow"
             )
         outputs = {
@@ -718,7 +718,7 @@ def source_dispatchable_fix(model, dict_asset, **kwargs):
         source_dispatchable = solph.Source(label=dict_asset[LABEL], outputs=outputs,)
     else:
         if TIMESERIES in dict_asset:
-            logging.error(
+            logging.debug(
                 "Change code in D1/source_dispatchable: timeseries_normalized not the only key determining the flow"
             )
         outputs = {


### PR DESCRIPTION
Fix #418

**Changes proposed in this pull request**:
- Adapt and add logging messages for components added to the model in D1

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
--> Fails but fails with same error in `dev` branch


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
