### PR TITLE
residual value calculation of the specific capex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Here is a template for new release sections
 - Label of storage components (storage capacity, input power, output power) will by default be redefined to the name of the storage and this component (#415)
 - Version number and date is only to be edited in one file (#419)
 - Add `ìnputs` folder to `.gitignore` (#401)
+- Change the residual for capex in C2 and test_C2 (#289, #247)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)

--- a/docs/MVS_parameters.rst
+++ b/docs/MVS_parameters.rst
@@ -27,7 +27,7 @@ economic_data.csv
 
 **discount_factor**: Discount factor is the factor which accounts for the depreciation in the value of money in the future, compared to the current value of the same money. The common method is to calculate the weighted average cost of capital (WACC) and use it as the discount rate.
 
-**Project_duration**: The name of years the project is intended to be operational. 
+**Project_duration**: The name of years the project is intended to be operational. The project duration also sets the installation time of the assets used in the simulation. After the project ends these assets are 'sold' and the refund is charged against the initial investment costs.
 
 **tax**: Tax factor. 
 

--- a/src/C2_economic_functions.py
+++ b/src/C2_economic_functions.py
@@ -85,7 +85,7 @@ def capex_from_investment(investment_t0, lifetime, project_life, discount_factor
         linear_depreciation_last_investment = last_investment / lifetime
         capex = capex - linear_depreciation_last_investment * (
             number_of_investments * lifetime - project_life
-        )/(1 + discount_factor) ** (project_life)
+        ) / (1 + discount_factor) ** (project_life)
 
     return capex
 

--- a/src/C2_economic_functions.py
+++ b/src/C2_economic_functions.py
@@ -85,7 +85,7 @@ def capex_from_investment(investment_t0, lifetime, project_life, discount_factor
         linear_depreciation_last_investment = last_investment / lifetime
         capex = capex - linear_depreciation_last_investment * (
             number_of_investments * lifetime - project_life
-        )
+        )/(1 + discount_factor) ** (project_life)
 
     return capex
 

--- a/src/C2_economic_functions.py
+++ b/src/C2_economic_functions.py
@@ -82,6 +82,8 @@ def capex_from_investment(investment_t0, lifetime, project_life, discount_factor
         last_investment = first_time_investment / (
             (1 + discount_factor) ** ((number_of_investments - 1) * lifetime)
         )
+        # the residual of the capex at the end of the simulation time takes into
+        # account the value of the money by deviding by (1 + discount_factor) ** (project_life)
         linear_depreciation_last_investment = last_investment / lifetime
         capex = capex - linear_depreciation_last_investment * (
             number_of_investments * lifetime - project_life

--- a/src/C2_economic_functions.py
+++ b/src/C2_economic_functions.py
@@ -49,7 +49,11 @@ def crf(project_life, discount_factor):
 
 def capex_from_investment(investment_t0, lifetime, project_life, discount_factor, tax):
     """
-    Calculates the capital expenditures, also known as CapEx. CapEx represent the total funds used to acquire or upgrade an asset
+    Calculates the capital expenditures, also known as CapEx. CapEx represent the total funds used to acquire or upgrade an asset.
+    The specific capex is calculated by taking into account all future cash flows connected to the investment into one unit of the asset.
+    This includes reinvestments, operation and management costs, dispatch costs as well as a deduction of the residual value at project end.
+    The residual value is calculated with a linear depreciation of the last investment, ie. as a even share of the last investment over
+    the lifetime of the asset. The remaining value of the asset is translated in a present value and then deducted.
 
     :param investment_t0: first investment at the beginning of the project made at year 0
     :param lifetime: time period over which investments and re-investments can occur. can be equal to, longer or shorter than project_life

--- a/tests/test_C2_economic_functions.py
+++ b/tests/test_C2_economic_functions.py
@@ -18,8 +18,8 @@ crf = 0.12
 annuity = 35400
 annuity_factor = 1 / 0.12
 exp_capex_equal_project_life = 253000
-exp_capex_smaller_project_life = 273188.729
-exp_capex_bigger_project_life = 144571.428
+exp_capex_smaller_project_life = 307564.336
+exp_capex_bigger_project_life = 236882.783
 fuel_keys = {
     "fuel_price": 1.3,
     "fuel_price_change_annual": 0,


### PR DESCRIPTION
Fix #289, fix #247 

**residual value calculation should consider the time value of money when the asset is sold and not the money value at the beginning of the simulation (as it is now)**:
- divide the capex residual by -> (1 + discount_factor) ** (project_life)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
