### PR TITLE
Fix numpy doc import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,9 +38,9 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.imgmath",
-    "numpydoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
+    "sphinx.ext.numpydoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
**Changes proposed in this pull request**:
- The readthedocs build online fails, probably because of the sphinx extension

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
