### PR TITLE
Fix/readthedoc config file format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ sphinx:
 #  - pdf
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
-  install:
-    -requirements: docs/requirements.txt
+   version: 3.7
+   install:
+      - requirements: docs/requirements.txt
+      - requirements: requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Here is a template for new release sections
  - Pyppeteer package for OS X users in troubleshooting (#414)
  - Add an enhancement to the auto-report by printing the log messages such as warnings and errors (#417)
  - New `dict` `REQUIRED_JSON_PARAMETERS` to gather the required parameters from the json input files (#432)
- - `.readthedocs.yml` configuration file (#435)
+ - `.readthedocs.yml` configuration file (#435, #436)
 
 ### Changed
 - Use selenium to print the automatic project report, `python mvs_report.py -h` for help (#356)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,8 +39,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.imgmath",
     "sphinx.ext.autosummary",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.numpydoc",
+    "numpydoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
**Changes proposed in this pull request**:
- The indentation of the .yml file was bad

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
