### PR TITLE
Feature/add parser arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Here is a template for new release sections
 - Moved list of keys to be printed in "scalars.xlsx" to "constants_output.py" (#453)
 - Renamed "peak_flow" to `PEAK_FLOW` and "average_flow" to `AVERAGE_FLOW` (#453)
 - Changed function "E2.lcoe_asset()" and its tests, now processes one asset at a time (#453)
-- Added arguments `"-f", "-log", "warning"` to all `parse_args` in `tests`
+- Added arguments `"-f", "-log", "warning"` to all `parse_args` and `main()` in `tests` (#456)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Here is a template for new release sections
 - Moved list of keys to be printed in "scalars.xlsx" to "constants_output.py" (#453)
 - Renamed "peak_flow" to `PEAK_FLOW` and "average_flow" to `AVERAGE_FLOW` (#453)
 - Changed function "E2.lcoe_asset()" and its tests, now processes one asset at a time (#453)
+- Added arguments `"-f", "-log", "warning"` to all `parse_args` in `tests`
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,14 @@ Here is a template for new release sections
 - Renamed "peak_flow" to `PEAK_FLOW` and "average_flow" to `AVERAGE_FLOW` (#453)
 - Changed function "E2.lcoe_asset()" and its tests, now processes one asset at a time (#453)
 - Added arguments `"-f", "-log", "warning"` to all `parse_args` and `main()` in `tests` (#456)
+- File `Developing.rst` with new description of tests and conventions (#456)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)
 - `MaximumCap` from list of required parameters for `energyStorage` assets (#415)
 - `inputs` folder (#401)
 - `tests/test_benchmark.py` module (#401)
+- Outdated table of tests of MVS `docs/tables/table_tests.csv` (#456)
 
 ### Fixed
 - Deleted columns from ´fixcost.csv´ as this is currently not used (#362)

--- a/docs/Developing.rst
+++ b/docs/Developing.rst
@@ -4,7 +4,18 @@ Contributing to MVS
 
 Proposed workflow
 -----------------
-The workflow is described in the CONTRIBUTING.md file in the repository
+The workflow is described in the  `CONTRIBUTING.md file<https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md>`_ in the repository.
+
+
+Unit tests (pytests)
+--------------------
+
+When developing code for the MVS please make sure that you always also develop test in `tests`. We integrate those unit tests with `pytest`. 
+Make sure that your tests are as leightweight as possible - this means that you do not always have to run the whole code to test for one feature, but can test a function with a standalone tests. Please refer to the other tests that have already been introduced.
+
+Always aim for the test coverage button on `the main page of the github reprository <https://github.com/rl-institut/mvs_eland/>`_ to reach 100%!
+
+When you do have to run the MVS itself for a test, eg. for benchmark tests, please always use the agruments `-f -log warning` to make the test results better readable.
 
 Build documentation
 -------------------
@@ -25,12 +36,3 @@ Here is how to set that in pycharm
   :width: 600
   :alt: pycharm docstring's format setting
 
-Tests
------
-
-Some tests are integrated into the MVS reprository. They should execute correctly on each developer's computer after adding a new feature and will be tested when attempting to merge into the developer/master branch of the github project.
-
-.. csv-table:: Implemented tests
-   :file: ./tables/table_tests.csv
-   :widths: 30, 50, 70, 70
-   :header-rows: 1

--- a/docs/Developing.rst
+++ b/docs/Developing.rst
@@ -4,7 +4,7 @@ Contributing to MVS
 
 Proposed workflow
 -----------------
-The workflow is described in the  `CONTRIBUTING.md file<https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md>`_ in the repository.
+The workflow is described in the  `CONTRIBUTING.md file <https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md>`_ in the repository.
 
 
 Unit tests (pytests)

--- a/docs/tables/table_tests.csv
+++ b/docs/tables/table_tests.csv
@@ -1,4 +1,0 @@
-Name of test,Issue tested,Description,To-Do if test fails
-test_run_smoothly,Code not terminating,Test checking whether mvs_eland_tool.py runs through,Re-check execution of mvs_eland_tool.py and make sure it does not terminate.
-test_blacks_main,Code formatting,Python code is tested with [Blacks](https://github.com/psf/black) for correct formatting ie. line breaks and line lenghts. Tested for mvs_eland_tool.py.,Run 'black mvs_eland_tool.py' and commit changes with own commit message.
-test_blacks_code_folder,Code formatting,Python code is tested with [Blacks](https://github.com/psf/black) for correct formatting ie. line breaks and line lenghts. Tested for all python code files in './code_folder'.,Run 'code_folder/"*".py' and commit changes with own commit message.

--- a/src/A0_initialization.py
+++ b/src/A0_initialization.py
@@ -262,8 +262,8 @@ def process_user_arguments(
         (Optional) Determines which messages are used for terminal output (command line "-log")
             "debug": All logging messages
             "info": All informative messages and warnings (default)
-            "warnings": All warnings
-            "errors": Only errors
+            "warning": All warnings
+            "error": Only errors
     :param lp_file_output:
         Save linear equation system generated as lp file
     :param welcome_text:

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -35,7 +35,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_input_folder_is_copied_in_output_within_folder_named_input(self, m_args):
@@ -45,7 +45,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", fake_input_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", fake_input_path, "-o", test_out_path]
         ),
     )
     def test_input_folder_not_existing_raise_filenotfound_error(self, m_args):
@@ -54,7 +54,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", JSON_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warnings", "-ext", JSON_EXT]),
     )
     def test_if_json_opt_and_no_json_file_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -66,7 +66,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", fake_input_path, "-ext", JSON_EXT]
+            ["-f", "-log", "warnings", "-i", fake_input_path, "-ext", JSON_EXT]
         ),
     )
     def test_if_json_opt_and_more_than_one_json_file_in_input_folder_raise_fileexists_error(
@@ -83,7 +83,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", CSV_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warnings", "-ext", CSV_EXT]),
     )
     def test_if_csv_opt_and_csv_elements_folder_not_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -97,7 +97,7 @@ class TestProcessUserArguments:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 fake_input_path,
                 "-ext",
@@ -121,7 +121,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_log_opt_display_output_is_set_with_correct_value(self, m_args):
@@ -132,7 +132,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_path_output_folder_exists_raise_fileexists_error(self, m_args):
@@ -144,7 +144,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_f_opt_preexisting_path_output_folder_should_be_replaced(self, m_args):
@@ -161,7 +161,7 @@ class TestProcessUserArguments:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 test_in_path,
                 "-o",
@@ -176,7 +176,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-pdf"]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path, "-pdf"]
         ),
     )
     def test_if_pdf_opt_the_key_path_pdf_report_exists_in_user_inputs(self, m_args):
@@ -188,7 +188,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_no_pdf_opt_the_key_path_pdf_report_does_not_exist_in_user_inputs(
@@ -300,7 +300,7 @@ class TestCommandLineInput:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 os.path.join("tests", "inputs"),
                 "-o",

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -35,7 +35,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_input_folder_is_copied_in_output_within_folder_named_input(self, m_args):
@@ -45,7 +45,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", fake_input_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", fake_input_path, "-o", test_out_path]
         ),
     )
     def test_input_folder_not_existing_raise_filenotfound_error(self, m_args):
@@ -54,7 +54,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warnings", "-ext", JSON_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", JSON_EXT]),
     )
     def test_if_json_opt_and_no_json_file_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -66,7 +66,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", fake_input_path, "-ext", JSON_EXT]
+            ["-f", "-log", "warning", "-i", fake_input_path, "-ext", JSON_EXT]
         ),
     )
     def test_if_json_opt_and_more_than_one_json_file_in_input_folder_raise_fileexists_error(
@@ -83,7 +83,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warnings", "-ext", CSV_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", CSV_EXT]),
     )
     def test_if_csv_opt_and_csv_elements_folder_not_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -97,7 +97,7 @@ class TestProcessUserArguments:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 fake_input_path,
                 "-ext",
@@ -121,7 +121,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_log_opt_display_output_is_set_with_correct_value(self, m_args):
@@ -132,7 +132,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_path_output_folder_exists_raise_fileexists_error(self, m_args):
@@ -144,7 +144,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_f_opt_preexisting_path_output_folder_should_be_replaced(self, m_args):
@@ -161,7 +161,7 @@ class TestProcessUserArguments:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 test_in_path,
                 "-o",
@@ -176,7 +176,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path, "-pdf"]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-pdf"]
         ),
     )
     def test_if_pdf_opt_the_key_path_pdf_report_exists_in_user_inputs(self, m_args):
@@ -188,7 +188,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_no_pdf_opt_the_key_path_pdf_report_does_not_exist_in_user_inputs(
@@ -300,7 +300,7 @@ class TestCommandLineInput:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 os.path.join("tests", "inputs"),
                 "-o",

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -132,7 +132,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_path_output_folder_exists_raise_fileexists_error(self, m_args):

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -34,7 +34,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+        ),
     )
     def test_input_folder_is_copied_in_output_within_folder_named_input(self, m_args):
         initializing.process_user_arguments()
@@ -42,7 +44,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", fake_input_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", fake_input_path, "-o", test_out_path]
+        ),
     )
     def test_input_folder_not_existing_raise_filenotfound_error(self, m_args):
         with pytest.raises(FileNotFoundError):
@@ -61,7 +65,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", fake_input_path, "-ext", JSON_EXT]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", fake_input_path, "-ext", JSON_EXT]
+        ),
     )
     def test_if_json_opt_and_more_than_one_json_file_in_input_folder_raise_fileexists_error(
         self, m_args
@@ -88,7 +94,17 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", fake_input_path, "-ext", CSV_EXT, "-o", test_out_path]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-i",
+                fake_input_path,
+                "-ext",
+                CSV_EXT,
+                "-o",
+                test_out_path,
+            ]
         ),
     )
     def test_if_csv_opt_path_input_file_set_to_path_input_folder_mvs_csv_config_dot_json(
@@ -105,7 +121,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_log_opt_display_output_is_set_with_correct_value(self, m_args):
@@ -115,7 +131,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+        ),
     )
     def test_if_path_output_folder_exists_raise_fileexists_error(self, m_args):
         """The error message should advice the user to use -f option to force overwrite"""
@@ -125,7 +143,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+        ),
     )
     def test_if_f_opt_preexisting_path_output_folder_should_be_replaced(self, m_args):
         os.mkdir(self.test_out_path)
@@ -138,7 +158,10 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning",
+            [
+                "-f",
+                "-log",
+                "warning",
                 "-i",
                 test_in_path,
                 "-o",
@@ -153,7 +176,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-pdf"]
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-pdf"]
         ),
     )
     def test_if_pdf_opt_the_key_path_pdf_report_exists_in_user_inputs(self, m_args):
@@ -164,7 +187,9 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
+        ),
     )
     def test_if_no_pdf_opt_the_key_path_pdf_report_does_not_exist_in_user_inputs(
         self, m_args
@@ -272,7 +297,15 @@ class TestCommandLineInput:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", os.path.join("tests", "inputs"), "-o", TEST_OUTPUT_PATH]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-i",
+                os.path.join("tests", "inputs"),
+                "-o",
+                TEST_OUTPUT_PATH,
+            ]
         ),
     )
     def test_user_defined_output_path(self, mock_args):

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -34,7 +34,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
     )
     def test_input_folder_is_copied_in_output_within_folder_named_input(self, m_args):
         initializing.process_user_arguments()
@@ -42,7 +42,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", fake_input_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", fake_input_path, "-o", test_out_path]),
     )
     def test_input_folder_not_existing_raise_filenotfound_error(self, m_args):
         with pytest.raises(FileNotFoundError):
@@ -50,7 +50,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-ext", JSON_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", JSON_EXT]),
     )
     def test_if_json_opt_and_no_json_file_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -61,7 +61,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", fake_input_path, "-ext", JSON_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", fake_input_path, "-ext", JSON_EXT]),
     )
     def test_if_json_opt_and_more_than_one_json_file_in_input_folder_raise_fileexists_error(
         self, m_args
@@ -77,7 +77,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-ext", CSV_EXT]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-ext", CSV_EXT]),
     )
     def test_if_csv_opt_and_csv_elements_folder_not_in_input_folder_raise_filenotfound_error(
         self, m_args, tmpdir
@@ -88,7 +88,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", fake_input_path, "-ext", CSV_EXT, "-o", test_out_path]
+        ["-f", "-log", "warning", "-i", fake_input_path, "-ext", CSV_EXT, "-o", test_out_path]
         ),
     )
     def test_if_csv_opt_path_input_file_set_to_path_input_folder_mvs_csv_config_dot_json(
@@ -105,7 +105,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", test_in_path, "-log", "error", "-o", test_out_path]
+        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]
         ),
     )
     def test_if_log_opt_display_output_is_set_with_correct_value(self, m_args):
@@ -115,7 +115,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
     )
     def test_if_path_output_folder_exists_raise_fileexists_error(self, m_args):
         """The error message should advice the user to use -f option to force overwrite"""
@@ -125,7 +125,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", test_in_path, "-f", "-o", test_out_path]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
     )
     def test_if_f_opt_preexisting_path_output_folder_should_be_replaced(self, m_args):
         os.mkdir(self.test_out_path)
@@ -138,10 +138,9 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            [
+        ["-f", "-log", "warning",
                 "-i",
                 test_in_path,
-                "-f",
                 "-o",
                 os.path.join(test_out_path, "recursive_folder"),
             ]
@@ -154,7 +153,7 @@ class TestProcessUserArguments:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", test_in_path, "-o", test_out_path, "-pdf"]
+        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-pdf"]
         ),
     )
     def test_if_pdf_opt_the_key_path_pdf_report_exists_in_user_inputs(self, m_args):
@@ -165,7 +164,7 @@ class TestProcessUserArguments:
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-i", test_in_path, "-o", test_out_path]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path]),
     )
     def test_if_no_pdf_opt_the_key_path_pdf_report_does_not_exist_in_user_inputs(
         self, m_args
@@ -273,7 +272,7 @@ class TestCommandLineInput:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", os.path.join("tests", "inputs"), "-o", TEST_OUTPUT_PATH]
+        ["-f", "-log", "warning", "-i", os.path.join("tests", "inputs"), "-o", TEST_OUTPUT_PATH]
         ),
     )
     def test_user_defined_output_path(self, mock_args):

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -48,7 +48,7 @@ class TestTemporaryJsonFileDisposal:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 test_in_path,
                 "-o",
@@ -76,7 +76,7 @@ class TestTemporaryJsonFileDisposal:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 test_in_path,
                 "-o",

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -48,7 +48,7 @@ class TestTemporaryJsonFileDisposal:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 test_in_path,
                 "-o",
@@ -76,7 +76,7 @@ class TestTemporaryJsonFileDisposal:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 test_in_path,
                 "-o",

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -45,7 +45,7 @@ class TestTemporaryJsonFileDisposal:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
         ),
     )
     def test_load_json_removes_json_file_from_inputs_folder(self, m_args):
@@ -63,7 +63,7 @@ class TestTemporaryJsonFileDisposal:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
         ),
     )
     def test_load_json_copies_json_file_to_output_folder(self, m_args):

--- a/tests/test_B0_data_input_json.py
+++ b/tests/test_B0_data_input_json.py
@@ -45,7 +45,17 @@ class TestTemporaryJsonFileDisposal:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-i",
+                test_in_path,
+                "-o",
+                test_out_path,
+                "-ext",
+                CSV_EXT,
+            ]
         ),
     )
     def test_load_json_removes_json_file_from_inputs_folder(self, m_args):
@@ -63,7 +73,17 @@ class TestTemporaryJsonFileDisposal:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", test_in_path, "-o", test_out_path, "-ext", CSV_EXT]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-i",
+                test_in_path,
+                "-o",
+                test_out_path,
+                "-ext",
+                CSV_EXT,
+            ]
         ),
     )
     def test_load_json_copies_json_file_to_output_folder(self, m_args):

--- a/tests/test_E0_evaluation.py
+++ b/tests/test_E0_evaluation.py
@@ -38,7 +38,9 @@ DICT_AFTER = os.path.join(TEST_REPO_PATH, "dict_values_after_E0.pickle")
 
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
-    return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]),
+    return_value=PARSER.parse_args(
+        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]
+    ),
 )
 def setup_module(m_args):
     """Run the simulation up to module E0 and save dict_values before and after evaluation"""

--- a/tests/test_E0_evaluation.py
+++ b/tests/test_E0_evaluation.py
@@ -39,7 +39,7 @@ DICT_AFTER = os.path.join(TEST_REPO_PATH, "dict_values_after_E0.pickle")
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=PARSER.parse_args(
-        ["-f", "-log", "warnings", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]
+        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]
     ),
 )
 def setup_module(m_args):

--- a/tests/test_E0_evaluation.py
+++ b/tests/test_E0_evaluation.py
@@ -38,7 +38,7 @@ DICT_AFTER = os.path.join(TEST_REPO_PATH, "dict_values_after_E0.pickle")
 
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
-    return_value=PARSER.parse_args(["-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]),
+    return_value=PARSER.parse_args(["-f", "-log", "warning", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]),
 )
 def setup_module(m_args):
     """Run the simulation up to module E0 and save dict_values before and after evaluation"""

--- a/tests/test_E0_evaluation.py
+++ b/tests/test_E0_evaluation.py
@@ -39,7 +39,7 @@ DICT_AFTER = os.path.join(TEST_REPO_PATH, "dict_values_after_E0.pickle")
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]
+        ["-f", "-log", "warnings", "-i", TEST_INPUT_PATH, "-o", TEST_OUTPUT_PATH]
     ),
 )
 def setup_module(m_args):

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -217,7 +217,7 @@ class TestPDFReportCreation:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-o", OUTPUT_PATH, "-pdf"]
+            ["-f", "-log", "warnings", "-o", OUTPUT_PATH, "-pdf"]
         ),
     )
     def test_generate_pdf_report(self, m_args):

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -217,7 +217,7 @@ class TestPDFReportCreation:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warnings", "-o", OUTPUT_PATH, "-pdf"]
+            ["-f", "-log", "warning", "-o", OUTPUT_PATH, "-pdf"]
         ),
     )
     def test_generate_pdf_report(self, m_args):

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -216,7 +216,7 @@ class TestPDFReportCreation:
     )
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-o", OUTPUT_PATH, "-pdf"]),
+        return_value=PARSER.parse_args(["-f", "-log", "warning", "-o", OUTPUT_PATH, "-pdf"]),
     )
     def test_generate_pdf_report(self, m_args):
         """Run the simulation with -pdf option to make sure the pdf file is generated """

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -216,7 +216,9 @@ class TestPDFReportCreation:
     )
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=PARSER.parse_args(["-f", "-log", "warning", "-o", OUTPUT_PATH, "-pdf"]),
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-o", OUTPUT_PATH, "-pdf"]
+        ),
     )
     def test_generate_pdf_report(self, m_args):
         """Run the simulation with -pdf option to make sure the pdf file is generated """

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -107,7 +107,7 @@ class TestNetworkx:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 TEST_INPUT_PATH_NX_TRUE,
                 "-o",
@@ -134,7 +134,7 @@ class TestNetworkx:
             [
                 "-f",
                 "-log",
-                "warnings",
+                "warning",
                 "-i",
                 TEST_INPUT_PATH_NX_FALSE,
                 "-o",

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -103,7 +103,7 @@ class TestNetworkx:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-i", TEST_INPUT_PATH_NX_TRUE, "-o", TEST_OUTPUT_PATH, "-ext", "csv", "-f"]
+        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH_NX_TRUE, "-o", TEST_OUTPUT_PATH, "-ext", "csv"]
         ),
     )
     def test_if_networkx_graph_is_stored_save_plot_true(self, m_args):
@@ -120,14 +120,13 @@ class TestNetworkx:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            [
+        ["-f", "-log", "warning",
                 "-i",
                 TEST_INPUT_PATH_NX_FALSE,
                 "-o",
                 TEST_OUTPUT_PATH,
                 "-ext",
-                "csv",
-                "-f",
+                "csv"
             ]
         ),
     )

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -16,7 +16,7 @@ from src.constants import (
     PLOTS_NX,
     PLOTS_PERFORMANCE,
     PLOTS_COSTS,
-CSV_EXT
+    CSV_EXT,
 )
 from src.constants_json_strings import (
     LABEL,
@@ -104,7 +104,17 @@ class TestNetworkx:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH_NX_TRUE, "-o", TEST_OUTPUT_PATH, "-ext", CSV_EXT]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-i",
+                TEST_INPUT_PATH_NX_TRUE,
+                "-o",
+                TEST_OUTPUT_PATH,
+                "-ext",
+                CSV_EXT,
+            ]
         ),
     )
     def test_if_networkx_graph_is_stored_save_plot_true(self, m_args):
@@ -121,13 +131,16 @@ class TestNetworkx:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning",
+            [
+                "-f",
+                "-log",
+                "warning",
                 "-i",
                 TEST_INPUT_PATH_NX_FALSE,
                 "-o",
                 TEST_OUTPUT_PATH,
                 "-ext",
-                CSV_EXT
+                CSV_EXT,
             ]
         ),
     )

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -16,6 +16,7 @@ from src.constants import (
     PLOTS_NX,
     PLOTS_PERFORMANCE,
     PLOTS_COSTS,
+CSV_EXT
 )
 from src.constants_json_strings import (
     LABEL,
@@ -103,7 +104,7 @@ class TestNetworkx:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH_NX_TRUE, "-o", TEST_OUTPUT_PATH, "-ext", "csv"]
+        ["-f", "-log", "warning", "-i", TEST_INPUT_PATH_NX_TRUE, "-o", TEST_OUTPUT_PATH, "-ext", CSV_EXT]
         ),
     )
     def test_if_networkx_graph_is_stored_save_plot_true(self, m_args):
@@ -126,7 +127,7 @@ class TestNetworkx:
                 "-o",
                 TEST_OUTPUT_PATH,
                 "-ext",
-                "csv"
+                CSV_EXT
             ]
         ),
     )

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -107,7 +107,7 @@ class TestNetworkx:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 TEST_INPUT_PATH_NX_TRUE,
                 "-o",
@@ -134,7 +134,7 @@ class TestNetworkx:
             [
                 "-f",
                 "-log",
-                "warning",
+                "warnings",
                 "-i",
                 TEST_INPUT_PATH_NX_FALSE,
                 "-o",

--- a/tests/test_benchmark_simple_scenarios.py
+++ b/tests/test_benchmark_simple_scenarios.py
@@ -44,7 +44,8 @@ class TestACElectricityBus:
     def test_benchmark_AB_grid_pv(self, margs):
         use_case = "AB_grid_PV"
         main(
-            path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
+           overwrite=True,
+display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
         )
@@ -72,7 +73,8 @@ class TestACElectricityBus:
     def test_benchmark_AE_grid_battery(self, margs):
         use_case = "AE_grid_battery"
         main(
-            path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
+           overwrite=True,
+display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
         )
@@ -99,7 +101,8 @@ class TestACElectricityBus:
         excess = {}
         for case in use_case:
             main(
-                path_input_folder=os.path.join(TEST_INPUT_PATH, case),
+           overwrite=True,
+display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, case),
                 input_type=CSV_EXT,
                 path_output_folder=os.path.join(TEST_OUTPUT_PATH, case),
             )

--- a/tests/test_benchmark_simple_scenarios.py
+++ b/tests/test_benchmark_simple_scenarios.py
@@ -44,8 +44,9 @@ class TestACElectricityBus:
     def test_benchmark_AB_grid_pv(self, margs):
         use_case = "AB_grid_PV"
         main(
-           overwrite=True,
-display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
+            overwrite=True,
+            display_output="warnings",
+            path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
         )
@@ -73,8 +74,9 @@ display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_c
     def test_benchmark_AE_grid_battery(self, margs):
         use_case = "AE_grid_battery"
         main(
-           overwrite=True,
-display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
+            overwrite=True,
+            display_output="warnings",
+            path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
         )
@@ -101,8 +103,9 @@ display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, use_c
         excess = {}
         for case in use_case:
             main(
-           overwrite=True,
-display_output="warnings", path_input_folder=os.path.join(TEST_INPUT_PATH, case),
+                overwrite=True,
+                display_output="warnings",
+                path_input_folder=os.path.join(TEST_INPUT_PATH, case),
                 input_type=CSV_EXT,
                 path_output_folder=os.path.join(TEST_OUTPUT_PATH, case),
             )

--- a/tests/test_benchmark_simple_scenarios.py
+++ b/tests/test_benchmark_simple_scenarios.py
@@ -45,7 +45,7 @@ class TestACElectricityBus:
         use_case = "AB_grid_PV"
         main(
             overwrite=True,
-            display_output="warnings",
+            display_output="warning",
             path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
@@ -75,7 +75,7 @@ class TestACElectricityBus:
         use_case = "AE_grid_battery"
         main(
             overwrite=True,
-            display_output="warnings",
+            display_output="warning",
             path_input_folder=os.path.join(TEST_INPUT_PATH, use_case),
             input_type=CSV_EXT,
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
@@ -104,7 +104,7 @@ class TestACElectricityBus:
         for case in use_case:
             main(
                 overwrite=True,
-                display_output="warnings",
+                display_output="warning",
                 path_input_folder=os.path.join(TEST_INPUT_PATH, case),
                 input_type=CSV_EXT,
                 path_output_folder=os.path.join(TEST_OUTPUT_PATH, case),


### PR DESCRIPTION
Fix #312 

**Changes proposed in this pull request**:
- Adding agruments `-f -log warning` to all `parse_args` and `main()` in `tests`

Removing the logging messages requires that for every test the arguments `-log warning` (or `-log error`) are used. This should be accounted for in future pytests. It should still be added to the readthedocs / Contributing.md somewhere.

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
