### PR TITLE
Read the version.py module's content instead of importing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ Here is a template for new release sections
 - Added arguments `"-f", "-log", "warning"` to all `parse_args` and `main()` in `tests` (#456)
 - File `Developing.rst` with new description of tests and conventions (#456)
 - Added a setup_class (remove dir) to `test_B0.TestTemporaryJsonFileDisposal` (#379)
+- Created function to read version number and date from file instead of importing it from module
+ (#463)
 
 
 ### Removed

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -76,7 +76,9 @@ from src.constants_json_strings import (
 )
 
 # TODO link this to the version and date number @Bachibouzouk
-from mvs_eland_tool.version import version_num, version_date
+from src.utils import get_version_info
+
+version_num, version_date = get_version_info()
 
 OUTPUT_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER)
 CSV_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER, INPUTS_COPY, CSV_ELEMENTS)

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import pandas as pd
 from src.constants import (
+    REPO_PATH,
     JSON_FNAME,
     CSV_ELEMENTS,
     OUTPUT_FOLDER,
@@ -12,6 +13,21 @@ from src.constants import (
     MISSING_PARAMETERS_KEY,
     EXTRA_PARAMETERS_KEY,
 )
+
+
+def get_version_info():
+    """Return the version number and date
+
+    Returns
+    -------
+    version number and date as tuple
+    """
+    main_namespace = {}
+    exec(
+        open(os.path.join(REPO_PATH, "mvs_eland_tool", "version.py")).read(),
+        main_namespace,
+    )
+    return main_namespace["version_num"], main_namespace["version_date"]
 
 
 def find_json_input_folders(


### PR DESCRIPTION
Fix #462 

**Changes proposed in this pull request**:
- The version information are fetched from reading the version.py module and not importing it, therefore preventing circular imports

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
