### PR TITLE
Enable report compilation using `-pdf` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Here is a template for new release sections
  (#463)
 - Fixed E0.store_results_matrix(), now available types: 'str', 'bool', 'None', dict (with key VALUE), else ('int'/'float'). If KPI not in asset, no value is attributed. Added test for function (#468, #470)
 - Fixed main() calls in 'test_F1_plotting.py' (#468)
+- Added `pyppdf==0.0.12` to `requirements.txt` (#473)
 
 ### Removed
 - Selenium to print the automatic project report for help (#407)
@@ -96,6 +97,7 @@ Here is a template for new release sections
 - Input folder `tests/inputs` with simple example scenario (#420)
 - Description of storage efficiency in readthedocs (#457)
 - Bug connected to global variables (#356)
+- MVS can now be run with argument `-pdf` (fix pyppeteer issue) (#473)
 
 ## [0.3.0] - 2020-06-08
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ ply==3.11
 pygraphviz==1.5
 Pyomo==5.6.6
 pyparsing==2.4.2
+pyppdf==0.0.12
 pyppeteer==0.2.2
 python-dateutil==2.8.0
 pytz==2019.2

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -20,6 +20,7 @@ import pandas as pd
 import reverse_geocoder as rg
 import staticmap
 import asyncio
+import pyppdf.patch_pyppeteer
 from pyppeteer import launch
 
 from src.constants import (

--- a/tests/test_A0_initialization.py
+++ b/tests/test_A0_initialization.py
@@ -4,7 +4,7 @@ import shutil
 import mock
 import pytest
 
-import src.A0_initialization as initializing
+import src.A0_initialization as A0
 from mvs_eland_tool import main
 from .constants import (
     EXECUTE_TESTS_ON,
@@ -23,7 +23,7 @@ from .constants import (
     PATH_INPUT_FILE,
 )
 
-PARSER = initializing.create_parser()
+PARSER = A0.create_parser()
 
 
 class TestProcessUserArguments:
@@ -39,7 +39,7 @@ class TestProcessUserArguments:
         ),
     )
     def test_input_folder_is_copied_in_output_within_folder_named_input(self, m_args):
-        initializing.process_user_arguments()
+        A0.process_user_arguments()
         assert os.path.exists(os.path.join(self.test_out_path, INPUTS_COPY))
 
     @mock.patch(
@@ -50,7 +50,7 @@ class TestProcessUserArguments:
     )
     def test_input_folder_not_existing_raise_filenotfound_error(self, m_args):
         with pytest.raises(FileNotFoundError):
-            initializing.process_user_arguments()
+            A0.process_user_arguments()
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -61,7 +61,7 @@ class TestProcessUserArguments:
     ):
         """provide a temporary dir with no .json in it"""
         with pytest.raises(FileNotFoundError):
-            initializing.process_user_arguments(path_input_folder=tmpdir)
+            A0.process_user_arguments(path_input_folder=tmpdir)
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -79,7 +79,7 @@ class TestProcessUserArguments:
         with open(os.path.join(self.fake_input_path, "file2.json"), "w") as of:
             of.write("something")
         with pytest.raises(FileExistsError):
-            initializing.process_user_arguments()
+            A0.process_user_arguments()
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -89,7 +89,7 @@ class TestProcessUserArguments:
         self, m_args, tmpdir
     ):
         with pytest.raises(FileNotFoundError):
-            initializing.process_user_arguments(path_input_folder=tmpdir)
+            A0.process_user_arguments(path_input_folder=tmpdir)
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -113,7 +113,7 @@ class TestProcessUserArguments:
         """Check that the path_input_file is <path_input_folder>/mvs_csv_config.json """
         os.mkdir(self.fake_input_path)
         os.mkdir(os.path.join(self.fake_input_path, CSV_ELEMENTS))
-        user_inputs = initializing.process_user_arguments()
+        user_inputs = A0.process_user_arguments()
         assert user_inputs[PATH_INPUT_FILE] == os.path.join(
             self.fake_input_path, CSV_ELEMENTS, CSV_FNAME
         )
@@ -125,7 +125,7 @@ class TestProcessUserArguments:
         ),
     )
     def test_if_log_opt_display_output_is_set_with_correct_value(self, m_args):
-        initializing.process_user_arguments()
+        A0.process_user_arguments()
         # TODO check the logging level
         assert 1
 
@@ -139,7 +139,7 @@ class TestProcessUserArguments:
         """The error message should advice the user to use -f option to force overwrite"""
         os.mkdir(self.test_out_path)
         with pytest.raises(FileExistsError):
-            initializing.process_user_arguments()
+            A0.process_user_arguments()
 
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
@@ -152,7 +152,7 @@ class TestProcessUserArguments:
         some_file = os.path.join(self.test_out_path, "a_file.txt")
         with open(some_file, "w") as of:
             of.write("something")
-        initializing.process_user_arguments()
+        A0.process_user_arguments()
         assert os.path.exists(some_file) is False
 
     @mock.patch(
@@ -170,7 +170,7 @@ class TestProcessUserArguments:
         ),
     )
     def test_if_path_output_folder_recursive_create_full_path(self, m_args):
-        initializing.process_user_arguments()
+        A0.process_user_arguments()
         assert os.path.exists(os.path.join(self.test_out_path, "recursive_folder"))
 
     @mock.patch(
@@ -180,7 +180,7 @@ class TestProcessUserArguments:
         ),
     )
     def test_if_pdf_opt_the_key_path_pdf_report_exists_in_user_inputs(self, m_args):
-        user_inputs = initializing.process_user_arguments()
+        user_inputs = A0.process_user_arguments()
         assert user_inputs["path_pdf_report"] == os.path.join(
             self.test_out_path, PDF_REPORT
         )
@@ -194,7 +194,7 @@ class TestProcessUserArguments:
     def test_if_no_pdf_opt_the_key_path_pdf_report_does_not_exist_in_user_inputs(
         self, m_args
     ):
-        user_inputs = initializing.process_user_arguments()
+        user_inputs = A0.process_user_arguments()
         assert "path_pdf_report" not in user_inputs.keys()
 
     def teardown_method(self):
@@ -207,13 +207,9 @@ class TestProcessUserArguments:
 def test_check_input_path_posix():
     """Verify the code works on both windows and linux path systems"""
     if os.name == "posix":
-        folder = initializing.check_input_folder(
-            "{}/inputs/".format(TEST_REPO_PATH), JSON_EXT
-        )
+        folder = A0.check_input_folder("{}/inputs/".format(TEST_REPO_PATH), JSON_EXT)
     else:
-        folder = initializing.check_input_folder(
-            "{}\\inputs\\".format(TEST_REPO_PATH), JSON_EXT
-        )
+        folder = A0.check_input_folder("{}\\inputs\\".format(TEST_REPO_PATH), JSON_EXT)
 
     assert folder == os.path.join(JSON_PATH)
 
@@ -223,7 +219,7 @@ TEST_OUTPUT_PATH = os.path.join(".", "tests", "other")
 
 class TestCommandLineInput:
 
-    parser = initializing.create_parser()
+    parser = A0.create_parser()
 
     def test_input_folder(self):
         parsed = self.parser.parse_args(["-i", "input_folder"])


### PR DESCRIPTION
Fix #427

**Changes proposed in this pull request**:
- Added `pyppdf` to requirements, calls patch in `F2`

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)