### PR TITLE
Structure for input validity definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 
 ### Added
 - `Model_Assumptions` added, including outline for component models, bulletpoints on limitations, energyProviders and peak demand pricing model. (#454)
+- Proposal for a file where the default values of input parameters are defined (`constant_valid_intervals.py`). Might also be of use to automatically update the parameter descriptions in readthedocs?
 
 ### Changed
 - Definition of busses from assets: Now all INFLOW_DIRECTION / OUTFLOW_DIRECTION are translated into ENERGY_BUSSES (#454, #387)

--- a/src/constant_valid_intervals.py
+++ b/src/constant_valid_intervals.py
@@ -1,0 +1,78 @@
+import pandas as pd
+
+from src.constants_json_strings import *
+
+VALID_INTERVAL = "Valid interval"
+VALID_TYPE = "Valid type"
+PARAMETER_EXAMPLE = "Example"
+PARAMETER_DEFINITION = "Definition"
+DEFAULT = "Default value"
+def extend_definitions(parameter_definitions, parameter, valid_interval, valid_type, example, definition, default):
+
+    dict_parameter = {
+        parameter: {VALID_INTERVAL: valid_interval,
+                    VALID_TYPE: valid_type,
+                    PARAMETER_EXAMPLE: example,
+                    PARAMETER_DEFINITION: definition,
+                    DEFAULT: default}
+    }
+    parameter_definitions = parameter_definitions.append(pd.DataFrame.from_dict(dict_parameter))
+    return parameter_definitions
+
+parameter_definitions = pd.DataFrame(
+    columns=[LABEL, VALID_INTERVAL, VALID_TYPE, PARAMETER_EXAMPLE, PARAMETER_DEFINITION, DEFAULT])
+
+extend_definitions(parameter_definitions,
+                   parameter=UNIT,
+                   definition="Unit of a paramter",
+                   valid_interval=None,
+                   valid_type= str(),
+                   example="kW",
+                   default="kW"
+                   )
+
+extend_definitions(parameter_definitions,
+                   parameter=VALUE,
+                   definition="Value of a parameter, can be of different types",
+                   valid_interval=None,
+                   valid_type= None,
+                   example="float",
+                   default=None
+                   )
+
+extend_definitions(parameter_definitions,
+                   parameter=CURR,
+                   definition="Currency to be used in the simulation report",
+                   valid_interval=None,
+                   valid_type= str(),
+                   example="Euro",
+                   default="Euro"
+                   )
+
+extend_definitions(parameter_definitions,
+                   parameter=DISCOUNTFACTOR,
+                   definition="Discount factor to be used for the economic evaluation",
+                   valid_interval=[0,1],
+                   valid_type= float(),
+                   example=0.1,
+                   default=0.1
+                   )
+
+
+extend_definitions(parameter_definitions,
+                   parameter=LABEL,
+                   definition="Label of an asset",
+                   valid_interval=None,
+                   valid_type= str(),
+                   example="Asset 1",
+                   default=None # this means that the asset name is required and a simulation does not run though without
+                   )
+
+extend_definitions(parameter_definitions,
+                   parameter=TAX,
+                   definition="Tax added on top of all costs (OM, investment, expenses)",
+                   valid_interval=[0,1],
+                   valid_type= float(),
+                   example=0.1,
+                   default=0.0
+                   )


### PR DESCRIPTION
Concerns #216 
Concerns #268

**Changes proposed in this pull request**:
- Add a `constants_valid_intervals.py` file which can serve as a reference both for validating the inputs in C0/C1 and the readthedocs pages (which could be defined by a script running though the file).

@Bachibouzouk: I was thinking on how to define the valid types/intervals for our input parameters. Currently, this is kind of included requiring a certain type for a certain unit, with some warnings in place. But in the end, we should be able to apply something like [this function](https://github.com/rl-institut/mvs_eland/blob/dev/src/C1_verification.py#L129), which is currently not applied. 
At the same time, we need to write the readthedocs page for the input parameters (@mahendrark does this in PR #479). I was wondering if we can shorten this.
My proposal: Define the json string of a parameter in a `constants.py` file and define all other info (type, interval, definition, example, default) in another python file `constants_valid_intervals.py`. A function checking for units etc can then simply go though the `pd.DataFrame` from the latter file, and display both a definition as well as the default values if necessary. Probably we could also write a code that automatically updates the readthedocs `.rst` file with the most recent definitions.

I was also thinking on how to do this with the 
```
def PARAMETER():
   parameter = "string"
   return parameter
```
Which we thought of due to the `.copy()` issues, but I did not come up with an idea.


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
