### PR TITLE
Display error message when feed-in tariff > electricity price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 
 ### Added
 - Also components that have no investment costs now have a value (of 0) for COST_INVESTMENT and COST_UPFRONT
+- Display error message when feed-in tariff > electricity price of any  asset in 'energyProvider.csv'. (#497)
 
 ### Changed
  - Move and rename json converter and parser to B0 module (#464)

--- a/src/C0_data_processing.py
+++ b/src/C0_data_processing.py
@@ -64,6 +64,8 @@ def all(dict_values):
     # todo check whether input values can be true
     # verify.check_input_values(dict_values)
     # todo Check, whether files (demand, generation) are existing
+    # check electricity price >= feed-in tariff todo: can be integrated into check_input_values() later
+    verify.check_feedin_tariff(dict_values=dict_values)
 
     # Adds costs to each asset and sub-asset
     process_all_assets(dict_values)

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -92,12 +92,17 @@ def check_feedin_tariff(dict_values):
 
     """
     for provider in dict_values["energyProviders"].keys():
-        feedin_tariff = dict_values["energyProviders"][provider]["feedin_tariff"]["value"]
-        electricity_price = dict_values["energyProviders"][provider]["energy_price"]["value"]
+        feedin_tariff = dict_values["energyProviders"][provider]["feedin_tariff"][
+            "value"
+        ]
+        electricity_price = dict_values["energyProviders"][provider]["energy_price"][
+            "value"
+        ]
         if feedin_tariff > electricity_price:
             msg = f"Feed-in tariff > energy price of energy provider asset '{dict_values['energyProviders'][provider]['label']}' would cause an unbound solution."
             raise ValueError(msg)
     return
+
 
 def check_input_values(dict_values):
     """

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -5,6 +5,7 @@ In A1/B0, the input parameters were parsed to str/bool/float/int. This module
 tests whether the parameters are in correct value ranges:
 - Display error message when wrong type
 - Display error message when outside defined range
+- Display error message when feed-in tariff > electriciy price (would cause loop, see #119)
 
 """
 
@@ -74,6 +75,21 @@ def lookup_file(file_path, name):
         raise FileNotFoundError(msg)
     return
 
+
+def check_feedin_tariff(dict_values):
+    r"""
+    Raises error if feed-in tariff > energy price of any asset in 'energyProvider.csv'.
+
+    Parameters
+    ----------
+    dict_values : dict
+        Contains all input data of the simulation.
+
+    Returns
+    -------
+
+    """
+    pass
 
 def check_input_values(dict_values):
     """

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -5,7 +5,7 @@ In A1/B0, the input parameters were parsed to str/bool/float/int. This module
 tests whether the parameters are in correct value ranges:
 - Display error message when wrong type
 - Display error message when outside defined range
-- Display error message when feed-in tariff > electriciy price (would cause loop, see #119)
+- Display error message when feed-in tariff > electricity price (would cause loop, see #119)
 
 """
 
@@ -87,9 +87,17 @@ def check_feedin_tariff(dict_values):
 
     Returns
     -------
+    Indirectly, raises error message in case of feed-in tariff > energy price of any
+    asset in 'energyProvider.csv'.
 
     """
-    pass
+    for provider in dict_values["energyProviders"].keys():
+        feedin_tariff = dict_values["energyProviders"][provider]["feedin_tariff"]["value"]
+        electricity_price = dict_values["energyProviders"][provider]["energy_price"]["value"]
+        if feedin_tariff > electricity_price:
+            msg = f"Feed-in tariff > energy price of energy provider asset '{dict_values['energyProviders'][provider]['label']}' would cause an unbound solution."
+            raise ValueError(msg)
+    return
 
 def check_input_values(dict_values):
     """

--- a/src/C1_verification.py
+++ b/src/C1_verification.py
@@ -99,7 +99,7 @@ def check_feedin_tariff(dict_values):
             "value"
         ]
         if feedin_tariff > electricity_price:
-            msg = f"Feed-in tariff > energy price of energy provider asset '{dict_values['energyProviders'][provider]['label']}' would cause an unbound solution."
+            msg = f"Feed-in tariff > energy price of energy provider asset '{dict_values['energyProviders'][provider]['label']}' would cause an unbound solution and terminate the optimization."
             raise ValueError(msg)
     return
 

--- a/tests/test_C1_verification.py
+++ b/tests/test_C1_verification.py
@@ -17,6 +17,32 @@ def test_lookup_file_non_existing_file_raises_error():
         C1.lookup_file(file_path=file_name, name="test")
 
 
+def test_check_feedin_tariff_greater_energy_price():
+    dict_values = {
+        "energyProviders": {
+            "DSO": {
+                "energy_price": {"unit": "currency/kWh", "value": 0.3},
+                "feedin_tariff": {"unit": "currency/kWh", "value": 0.4},
+                "label": "test DSO",
+            }
+        }
+    }
+    with pytest.raises(ValueError):
+        C1.check_feedin_tariff(dict_values)
+
+
+def test_check_feedin_tariff_not_greater_energy_price():
+    dict_values = {
+        "energyProviders": {
+            "DSO": {
+                "energy_price": {"unit": "currency/kWh", "value": 0.5},
+                "feedin_tariff": {"unit": "currency/kWh", "value": 0.4},
+                "label": "test DSO",
+            }
+        }
+    }
+    C1.check_feedin_tariff(dict_values)
+
 # def test_check_input_values():
 #     pass
 #     # todo note: function is not used so far

--- a/tests/test_C1_verification.py
+++ b/tests/test_C1_verification.py
@@ -43,6 +43,7 @@ def test_check_feedin_tariff_not_greater_energy_price():
     }
     C1.check_feedin_tariff(dict_values)
 
+
 # def test_check_input_values():
 #     pass
 #     # todo note: function is not used so far


### PR DESCRIPTION
see #119 - does not fix the whole issue

**Changes proposed in this pull request**:
- Display error message when feed-in tariff > electricity price of any  asset in 'energyProvider.csv'.

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
:x: For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
