### PR TITLE
Set logging message from Flask server to Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Here is a template for new release sections
 - Changed dostring format in `C2` to numpy (#495)
 - Deactivated function `C2.fuel_price_present_value` as it is not used and TBD (#495)
 - Modified the doc-strings in the definitions of some functions to abide by the formatting rules of numpy doc-strings (#505)
+- Suppressed the log messages of the Flask server (for report webapp) (#509) 
 
 ### Removed
 -

--- a/src/F2_autoreport.py
+++ b/src/F2_autoreport.py
@@ -33,6 +33,10 @@ import logging
 pyppeteer_level = logging.WARNING
 logging.getLogger("pyppeteer").setLevel(pyppeteer_level)
 
+# This removes extensive logging in the console for the dash app (it runs on Flask server)
+flask_log = logging.getLogger("werkzeug")
+flask_log.setLevel(logging.ERROR)
+
 from src.constants import (
     PLOTS_BUSSES,
     PATHS_TO_PLOTS,


### PR DESCRIPTION
Fix #481 

**Changes proposed in this pull request**:
- Suppressed the log messages of the Flask server (for report webapp)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
