### PR TITLE
Fix/benchmark peak pricing

### DIFF
--- a/tests/test_benchmark_simple_scenarios.py
+++ b/tests/test_benchmark_simple_scenarios.py
@@ -229,7 +229,7 @@ class TestACElectricityBus:
             - busses_flow["Electricity grid DSO_consumption_period_3"]
         )  # todo: replace this by discharge column when implemented
         # look for peak demand in period
-        for j in range(0, 2):
+        for j in range(0, 3):
             for i in range(0, len(DSO_periods[1])):
                 if (
                     DSO_periods[j][i] == peak_demand[j]


### PR DESCRIPTION
I was confused with the battery charge being able to have negative values, so I fixed it with `abs()` and had to change the structure for that a bit. I also added descriptions.