### PR TITLE
Allow plotting only a few days of timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Here is a template for new release sections
 ### Removed
 - `E2.add_costs_and_total`() (#520)
 - Calculation of energy expenditures using `price` (#520)
+- Function `F1.plot_input_timeseries` which is based on matplotlib
 
 ### Fixed
 - Calculation of `cost_upfront` required a multiplication (#520)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections
 - Explicit calculation of replacement costs (`C2.get_replacement_costs()`), so that they can be used in `E2` for installed capacities and optimal additional capacities (#520)
 - New constant variable: JSON_WITH_RESULTS="json_with_results.json" (#520)
 - Benchmark test "Economic_KPI_C2_E2" to test economic evaluations in C2 and E2 (#520)
+- Possibility to add an upper bound  on the number of days to display in a timeseries' plot (#526)
 
 ### Changed
 - Changed structure for `E2.get_cost()` and complete disaggregation of the formulas used in it (#520)

--- a/src/F0_output.py
+++ b/src/F0_output.py
@@ -76,10 +76,18 @@ def evaluate_dict(dict_values, path_pdf_report=None, path_png_figs=None):
         F1_plots.plot_timeseries(
             dict_values, data_type=DEMANDS, file_path=path_png_figs
         )
+        # plot demand timeseries for the first 2 weeks only
+        F1_plots.plot_timeseries(
+            dict_values, data_type=DEMANDS, max_days=14, file_path=path_png_figs
+        )
 
         # plot supply timeseries
         F1_plots.plot_timeseries(
             dict_values, data_type=RESOURCES, file_path=path_png_figs
+        )
+        # plot supply timeseries for the first 2 weeks only
+        F1_plots.plot_timeseries(
+            dict_values, data_type=RESOURCES, max_days=14, file_path=path_png_figs
         )
 
         # plot power flows in the energy system

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -466,7 +466,7 @@ def create_plotly_line_fig(
     return fig
 
 
-def plot_timeseries(dict_values, data_type=DEMANDS, file_path=None):
+def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=None):
     r"""Plot timeseries as line chart.
 
     Parameters
@@ -477,6 +477,9 @@ def plot_timeseries(dict_values, data_type=DEMANDS, file_path=None):
     data_type: str
         one of DEMANDS or RESOURCES
         Default: DEMANDS
+
+    max_days: int
+        maximal number of days the timeserie should be displayed for
 
     file_path: str
         Path where the image shall be saved if not None
@@ -506,6 +509,10 @@ def plot_timeseries(dict_values, data_type=DEMANDS, file_path=None):
         "#DEB841",
         "#4F3130",
     ]
+
+    if max_days is not None:
+        max_date = df_pd["timestamp"][0] + pd.Timedelta('{} day'.format(max_days))
+        df_pd = df_pd.loc[df_pd["timestamp"] < max_date]
     for (component, color_plot) in zip(list_of_keys, colors_list):
         comp_id = component + "-plot"
         fig = create_plotly_line_fig(

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -511,7 +511,7 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
     ]
 
     if max_days is not None:
-        max_date = df_pd["timestamp"][0] + pd.Timedelta('{} day'.format(max_days))
+        max_date = df_pd["timestamp"][0] + pd.Timedelta("{} day".format(max_days))
         df_pd = df_pd.loc[df_pd["timestamp"] < max_date]
         title_addendum = " ({} days)".format(max_days)
     else:

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -261,69 +261,6 @@ def draw_graph(
         )
 
 
-def plot_input_timeseries(
-    dict_values,
-    user_input,
-    timeseries,
-    asset_name,
-    column_head="",
-    is_demand_profile=False,
-):
-    r"""
-    This function is called from C0 to plot the input timeseries provided to the MVS.
-    This includes demand profiles, generation profiles as well as timeseries for otherwise scalar
-    values.
-
-    Parameters
-    ----------
-    dict_values: dict
-        Dict with all simulation parameters
-
-    user_input: dict
-        Settings
-
-    timeseries: pd.Series
-        Timeseries to be plotted
-
-    asset_name: str
-        Name of the timeseries to be plotted
-
-    column_head: str
-        Column under which timeseries can be found in the csv
-
-    is_demand_profile: bool
-        Information whether or not the timeseries provided is a demand profile
-
-    Returns
-    -------
-    PNG file with timeseries plot
-
-    """
-    logging.info("Creating plots for asset %s's parameter %s", asset_name, column_head)
-    fig, axes = plt.subplots(nrows=1, figsize=(16 / 2.54, 10 / 2.54 / 2))
-    axes_mg = axes
-
-    timeseries.plot(
-        title=asset_name, ax=axes_mg, drawstyle="steps-mid",
-    )
-    axes_mg.set(xlabel="Time", ylabel=column_head)
-    path = os.path.join(
-        user_input[PATH_OUTPUT_FOLDER],
-        "input_timeseries_" + asset_name + "_" + column_head + ".png",
-    )
-    if is_demand_profile is True:
-        dict_values[PATHS_TO_PLOTS][PLOTS_DEMANDS] += [str(path)]
-    else:
-        dict_values[PATHS_TO_PLOTS][PLOTS_RESOURCES] += [str(path)]
-    plt.savefig(
-        path, bbox_inches="tight",
-    )
-
-    plt.close()
-    plt.clf()
-    plt.cla()
-
-
 def save_plots_to_disk(
     fig_obj, file_name, file_path="", width=None, height=None, scale=None
 ):

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -513,12 +513,16 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
     if max_days is not None:
         max_date = df_pd["timestamp"][0] + pd.Timedelta('{} day'.format(max_days))
         df_pd = df_pd.loc[df_pd["timestamp"] < max_date]
+        title_addendum = " ({} days)".format(max_days)
+    else:
+        title_addendum = ""
+
     for (component, color_plot) in zip(list_of_keys, colors_list):
         comp_id = component + "-plot"
         fig = create_plotly_line_fig(
             x_data=df_pd["timestamp"],
             y_data=df_pd[component],
-            plot_title=dict_plot_labels[component],
+            plot_title="{}{}".format(dict_plot_labels[component], title_addendum),
             x_axis_name="Time",
             y_axis_name="kW",
             color_for_plot=color_plot,


### PR DESCRIPTION
Fix #515 

**Changes proposed in this pull request**:
- Possibility to add an upper bound  on the number of days to display in a timeseries' plot

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
