### PR TITLE
Fix the hardcoded color lists in the figure creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - Changed and added pytests in for `C2` (#520)
 - All energyProviders that have key `FILENAME` (and, therefore, a timeseries), are now of `DISPATCHABILITY = False`(#520)
 - Changed structure of `E2.lcoe_assets()` so that each asset has a defined LCOE_ASSET. If `sum(FLOW)==0` of an asset, the LCOE_ASSET (utilization LCOE) is defined to be 0 (#520)
+- Color lists for plots are provided by user and are not hard coded anymore (#527)
 
 ### Removed
 - `E2.add_costs_and_total`() (#520)

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -437,7 +437,9 @@ def create_plotly_line_fig(
     return fig
 
 
-def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=None):
+def plot_timeseries(
+    dict_values, data_type=DEMANDS, max_days=None, color_list=None, file_path=None
+):
     r"""Plot timeseries as line chart.
 
     Parameters
@@ -451,6 +453,10 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
 
     max_days: int
         maximal number of days the timeserie should be displayed for
+
+    color_list: list of str or list to tuple (hexadecimal or rbg code)
+        list of colors
+        Default: None
 
     file_path: str
         Path where the image shall be saved if not None
@@ -471,15 +477,6 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
     list_of_keys = list(df_pd.columns)
     list_of_keys.remove("timestamp")
     plots = {}
-    # TODO if the number of plots is larger than this list, it will not plot more
-    colors_list = [
-        "royalblue",
-        "#3C5233",
-        "firebrick",
-        "#002500",
-        "#DEB841",
-        "#4F3130",
-    ]
 
     if max_days is not None:
         max_date = df_pd["timestamp"][0] + pd.Timedelta("{} day".format(max_days))
@@ -488,7 +485,7 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
     else:
         title_addendum = ""
 
-    for (component, color_plot) in zip(list_of_keys, colors_list):
+    for i, component in enumerate(list_of_keys):
         comp_id = component + "-plot"
         fig = create_plotly_line_fig(
             x_data=df_pd["timestamp"],
@@ -496,7 +493,7 @@ def plot_timeseries(dict_values, data_type=DEMANDS, max_days=None, file_path=Non
             plot_title="{}{}".format(dict_plot_labels[component], title_addendum),
             x_axis_name="Time",
             y_axis_name="kW",
-            color_for_plot=color_plot,
+            color_for_plot=get_color(i, color_list),
             file_path=file_path,
         )
         if file_path is None:
@@ -668,6 +665,7 @@ def create_plotly_flow_fig(
     x_legend=None,
     y_legend=None,
     plot_title=None,
+    color_list=None,
     file_name="flows.png",
     file_path=None,
 ):
@@ -686,6 +684,10 @@ def create_plotly_flow_fig(
     plot_title: str
         Default: None
 
+    color_list: list of str or list to tuple (hexadecimal or rbg code)
+        list of colors
+        Default: None
+
     file_name: str
         Name of the image file.
         Default: "flows.png"
@@ -701,32 +703,19 @@ def create_plotly_flow_fig(
     """
 
     fig = go.Figure()
-    # TODO: if number of asset is larger than this list, the surnumerrous will not be plotted
-    colors = [
-        "#1f77b4",
-        "#ff7f0e",
-        "#2ca02c",
-        "#d62728",
-        "#9467bd",
-        "#8c564b",
-        "#e377c2",
-        "#7f7f7f",
-        "#bcbd22",
-        "#17becf",
-    ]
     styling_dict = get_fig_style_dict()
     styling_dict["gridwidth"] = 1.0
 
     assets_list = list(df_plots_data.columns)
     assets_list.remove("timestamp")
 
-    for asset, new_color in zip(assets_list, colors):
+    for i, asset in enumerate(assets_list):
         fig.add_trace(
             go.Scatter(
                 x=df_plots_data["timestamp"],
                 y=df_plots_data[asset],
                 mode="lines",
-                line=dict(color=new_color, width=2.5),
+                line=dict(color=get_color(i, color_list), width=2.5),
                 name=asset,
             )
         )

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -261,6 +261,40 @@ def draw_graph(
         )
 
 
+def get_color(idx_line, color_list=None):
+    """Pick a color within a color list with periodic boundary conditions
+
+    Parameters
+    ----------
+    idx_line: int
+        index of the line in a plot for which a color is required
+
+    colors: list of str or list to tuple (hexadecimal or rbg code)
+        list of colors
+        Default: None
+
+    Returns
+    -------
+    The color in the color list corresponding to the index modulo the color list length
+
+    """
+    if color_list is None:
+        color_list = (
+            "#1f77b4",
+            "#ff7f0e",
+            "#2ca02c",
+            "#d62728",
+            "#9467bd",
+            "#8c564b",
+            "#e377c2",
+            "#7f7f7f",
+            "#bcbd22",
+            "#17becf",
+        )
+    n_colors = len(color_list)
+    return color_list[idx_line % n_colors]
+
+
 def save_plots_to_disk(
     fig_obj, file_name, file_path="", width=None, height=None, scale=None
 ):

--- a/tests/test_F1_plotting.py
+++ b/tests/test_F1_plotting.py
@@ -191,3 +191,8 @@ class TestFileCreation:
         """ """
         if os.path.exists(OUTPUT_PATH):
             shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
+
+
+def test_get_color_is_cyclic():
+    colors = [1, 2, 3]
+    assert F1.get_color(3, colors) == colors[0]


### PR DESCRIPTION
Fix #517

**Changes proposed in this pull request**:
- Color lists for plots are provided by user and are not hard coded anymore

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
