### PR TITLE
Prevent error if timeseries to plot is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Here is a template for new release sections
 - Fixed parsing issue in `A1.conversion()`, incl. pytest (#538)
 - Quick fix to read a timeseries for `"price"` in `C0.define_source()` (#524)
 - Fix `C1.check_feedin_tariff()`: Now also applyable to timeseries of feed-in tariff or electricity prices (#524)
+- Add a warning message if the timeseries of demands or resources are empty (#543)
 
 ## [0.3.3] - 2020-08-19
 

--- a/src/F1_plotting.py
+++ b/src/F1_plotting.py
@@ -620,8 +620,11 @@ def plot_timeseries(
     plots = {}
 
     if max_days is not None:
-        max_date = df_pd["timestamp"][0] + pd.Timedelta("{} day".format(max_days))
-        df_pd = df_pd.loc[df_pd["timestamp"] < max_date]
+        if df_pd["timestamp"].empty:
+            logging.warning("The timeseries for {} are empty".format(data_type))
+        else:
+            max_date = df_pd["timestamp"][0] + pd.Timedelta("{} day".format(max_days))
+            df_pd = df_pd.loc[df_pd["timestamp"] < max_date]
         title_addendum = " ({} days)".format(max_days)
     else:
         title_addendum = ""


### PR DESCRIPTION
Fix #543 

**Changes proposed in this pull request**:
- Add a warning message if the timeseries of demands or resources are empty

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
