### PR TITLE
Fix C1.check_feedin_tariff()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Here is a template for new release sections
 -
 ```
 
+## [Unreleased]
+
+### Added
+-
+### Changed
+-
+### Removed
+-
+### Fixed
+- `C1.check_feedin_tariff()` now also accepts `isinstance(diff, int)` (#552)
+
 ## [0.4.0] - 2020-09-01
 
 ### Added

--- a/src/mvs_eland/C1_verification.py
+++ b/src/mvs_eland/C1_verification.py
@@ -99,7 +99,7 @@ def check_feedin_tariff(dict_values):
         feedin_tariff = dict_values[ENERGY_PROVIDERS][provider][FEEDIN_TARIFF]
         electricity_price = dict_values[ENERGY_PROVIDERS][provider][ENERGY_PRICE]
         diff = feedin_tariff[VALUE] - electricity_price[VALUE]
-        if isinstance(diff, float):
+        if isinstance(diff, float) or isinstance(diff, int):
             if diff > 0:
                 msg = f"Feed-in tariff > energy price for the energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}' would cause an unbound solution and terminate the optimization. Please reconsider your feed-in tariff and energy price."
                 raise ValueError(msg)


### PR DESCRIPTION
Fix #550 

**Changes proposed in this pull request**:
- Now diff can also be of type int

Notes:
- There are still some pytests missing for the function, specifically for prices/tariffs provided as a timeseries

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
