### PR TITLE
Fix faulty minimal renewable share criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Here is a template for new release sections
 
 ### Added
 - Evaluation of excess energy for each of the energy carriers and for the whole system. The excess per sector and their energy equivalent may currently be faulty (comp. issue #559) (#555)
-- Debug messages for `C0` tests (#555)
+- Debug messages for pytests: `C0`, `D2` (#555, #560)
 
 ### Changed
 - `C1.total_demand_each_sector()` to `C1.total_demand_and_excess_each_sector()`, now also evaluating the excess energy flows (#555)
@@ -35,13 +35,14 @@ Here is a template for new release sections
 - Change logging level of some messages from `logging.info` to `logging.debug` (#555)
 - Move and rename json input files for D0 and D1 tests (`test_data_for_D0.json` to `tests/test_data/inputs_for_D0/mvs_config.json`, `test_data_for_D1.json` to `tests/test_data/inputs_for_D1/mvs_config.json`), add required parameters (#555) 
 - Change requirements/test.txt: `black==19.10b0`, as otherwise there are incompatabilities (#555)
-
+- `D2.prepare_constraint_minimal_renewable_share`, including logging messages and pytest (#560)
 ### Removed
--
+
 
 ### Fixed
 - `C1.check_feedin_tariff()` now also accepts `isinstance(diff, int)` (#552)
 - Feed-in sinks of the DSOs now are capacity-optimized and can actually be used (#555)
+- Incorrectly applied minimal renewable share criterion (#560)
 
 ## [0.4.0] - 2020-09-01
 

--- a/src/mvs_eland/D2_model_constraints.py
+++ b/src/mvs_eland/D2_model_constraints.py
@@ -280,21 +280,20 @@ def prepare_constraint_minimal_renewable_share(
     for dso in dict_values[ENERGY_PROVIDERS]:
         # Get source connected to the specific DSO in question
         DSO_source_name = dso + DSO_CONSUMPTION
-
         # Add DSO to both renewable and nonrenewable assets (as only a share of their supply may be renewable)
         dso_sources.append(DSO_source_name)
 
         renewable_assets.update(
             {
-                asset: {
+                DSO_source_name: {
                     oemof_solph_object_asset: dict_model[OEMOF_SOURCE][
                         dict_values[ENERGY_PRODUCTION][DSO_source_name][LABEL]
                     ],
                     oemof_solph_object_bus: dict_model[OEMOF_BUSSES][
-                        dict_values[ENERGY_PRODUCTION][asset][OUTPUT_BUS_NAME]
+                        dict_values[ENERGY_PRODUCTION][DSO_source_name][OUTPUT_BUS_NAME]
                     ],
                     weighting_factor_energy_carrier: DEFAULT_WEIGHTS_ENERGY_CARRIERS[
-                        dict_values[ENERGY_PRODUCTION][asset][ENERGY_VECTOR]
+                        dict_values[ENERGY_PRODUCTION][DSO_source_name][ENERGY_VECTOR]
                     ][VALUE],
                     renewable_share_asset_flow: dict_values[ENERGY_PROVIDERS][dso][
                         RENEWABLE_SHARE_DSO
@@ -304,15 +303,15 @@ def prepare_constraint_minimal_renewable_share(
         )
         non_renewable_assets.update(
             {
-                asset: {
+                DSO_source_name: {
                     oemof_solph_object_asset: dict_model[OEMOF_SOURCE][
                         dict_values[ENERGY_PRODUCTION][DSO_source_name][LABEL]
                     ],
                     oemof_solph_object_bus: dict_model[OEMOF_BUSSES][
-                        dict_values[ENERGY_PRODUCTION][asset][OUTPUT_BUS_NAME]
+                        dict_values[ENERGY_PRODUCTION][DSO_source_name][OUTPUT_BUS_NAME]
                     ],
                     weighting_factor_energy_carrier: DEFAULT_WEIGHTS_ENERGY_CARRIERS[
-                        dict_values[ENERGY_PRODUCTION][asset][ENERGY_VECTOR]
+                        dict_values[ENERGY_PRODUCTION][DSO_source_name][ENERGY_VECTOR]
                     ][VALUE],
                     renewable_share_asset_flow: dict_values[ENERGY_PROVIDERS][dso][
                         RENEWABLE_SHARE_DSO
@@ -327,4 +326,13 @@ def prepare_constraint_minimal_renewable_share(
                 "There is an asset {k} that does not have any information whether it is of renewable origin or not. "
                 "It is neither a DSO source nor a renewable or fuel source."
             )
+
+    renewable_asset_string = ", ".join(map(str, renewable_assets.keys()))
+    non_renewable_asset_string = ", ".join(map(str, non_renewable_assets.keys()))
+
+    logging.debug(f"Data considered for the minimal renewable share constraint:")
+    logging.debug(f"Assets connected to renewable generation: {renewable_asset_string}")
+    logging.debug(
+        f"Assets connected to non-renewable generation: {non_renewable_asset_string}"
+    )
     return renewable_assets, non_renewable_assets

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -20,9 +20,13 @@ def test_prepare_constraint_minimal_renewable_share():
     diesel = "Diesel"
     electricity = "Electricity"
     fuel = "Fuel"
-    dso = "DSO"
+    dso_1 = "DSO_1"
+    dso_2 = "DSO_2"
     dict_values = {
-        ENERGY_PROVIDERS: {dso: {LABEL: dso, RENEWABLE_SHARE_DSO: {VALUE: 0.3}}},
+        ENERGY_PROVIDERS: {
+            dso_1: {LABEL: dso_1, RENEWABLE_SHARE_DSO: {VALUE: 0.3}},
+            dso_2: {LABEL: dso_2, RENEWABLE_SHARE_DSO: {VALUE: 0.7}},
+        },
         ENERGY_PRODUCTION: {
             pv_plant: {
                 RENEWABLE_ASSET_BOOL: {VALUE: True},
@@ -36,9 +40,15 @@ def test_prepare_constraint_minimal_renewable_share():
                 OUTPUT_BUS_NAME: fuel,
                 ENERGY_VECTOR: electricity,
             },
-            dso
+            dso_1
             + DSO_CONSUMPTION: {
-                LABEL: dso + DSO_CONSUMPTION,
+                LABEL: dso_1 + DSO_CONSUMPTION,
+                OUTPUT_BUS_NAME: electricity,
+                ENERGY_VECTOR: electricity,
+            },
+            dso_2
+            + DSO_CONSUMPTION: {
+                LABEL: dso_2 + DSO_CONSUMPTION,
                 OUTPUT_BUS_NAME: electricity,
                 ENERGY_VECTOR: electricity,
             },
@@ -48,7 +58,8 @@ def test_prepare_constraint_minimal_renewable_share():
         OEMOF_SOURCE: {
             pv_plant: pv_plant,
             diesel: diesel,
-            dso + DSO_CONSUMPTION: dso + DSO_CONSUMPTION,
+            dso_1 + DSO_CONSUMPTION: dso_1 + DSO_CONSUMPTION,
+            dso_2 + DSO_CONSUMPTION: dso_2 + DSO_CONSUMPTION,
         },
         OEMOF_BUSSES: {electricity: electricity, fuel: fuel},
     }
@@ -69,18 +80,50 @@ def test_prepare_constraint_minimal_renewable_share():
         oemof_solph_object_bus=oemof_solph_object_bus,
     )
 
-    assert pv_plant in renewable_assets
-    assert pv_plant not in non_renewable_assets
-    assert renewable_assets[pv_plant][renewable_share_asset_flow] == 1
-
-    assert diesel in non_renewable_assets
-    assert diesel not in renewable_assets
-    assert non_renewable_assets[diesel][renewable_share_asset_flow] == 0
-
-    assert dso + DSO_CONSUMPTION in renewable_assets
-    assert renewable_assets[dso + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.3
-
-    assert dso + DSO_CONSUMPTION in non_renewable_assets
     assert (
-        non_renewable_assets[dso + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.3
-    )
+        pv_plant in renewable_assets
+    ), f"The {pv_plant} is not added to the renewable assets."
+    assert (
+        pv_plant not in non_renewable_assets
+    ), f"The {pv_plant} is not added to the renewable assets."
+    assert (
+        renewable_assets[pv_plant][renewable_share_asset_flow] == 1
+    ), f"The renewable share of asset {pv_plant} is added incorrectly."
+
+    assert (
+        diesel in non_renewable_assets
+    ), f"The {diesel} is added to the renewable assets."
+    assert (
+        diesel not in renewable_assets
+    ), f"The {diesel} is not added to the non-renewable assets."
+    assert (
+        non_renewable_assets[diesel][renewable_share_asset_flow] == 0
+    ), f"The renewable share of asset {diesel} is added incorrectly."
+
+    assert (
+        dso_1 + DSO_CONSUMPTION in renewable_assets
+    ), f"The {dso_1 + DSO_CONSUMPTION} is not added as a renewable source."
+    assert (
+        renewable_assets[dso_1 + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.3
+    ), f"The renewable share of asset {dso_1 + DSO_CONSUMPTION} is added incorrectly."
+
+    assert (
+        dso_1 + DSO_CONSUMPTION in non_renewable_assets
+    ), f"The {dso_1 + DSO_CONSUMPTION} is not added as a non-renewable source."
+    assert (
+        non_renewable_assets[dso_1 + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.3
+    ), f"The renewable share of asset {dso_1 + DSO_CONSUMPTION} is added incorrectly."
+
+    assert (
+        dso_2 + DSO_CONSUMPTION in renewable_assets
+    ), f"The {dso_2 + DSO_CONSUMPTION} is not added as a renewable source."
+    assert (
+        renewable_assets[dso_2 + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.7
+    ), f"The renewable share of asset {dso_2 + DSO_CONSUMPTION} is added incorrectly."
+
+    assert (
+        dso_2 + DSO_CONSUMPTION in non_renewable_assets
+    ), f"The {dso_2 + DSO_CONSUMPTION} is not added as a non-renewable source."
+    assert (
+        non_renewable_assets[dso_2 + DSO_CONSUMPTION][renewable_share_asset_flow] == 0.7
+    ), f"The renewable share of asset {dso_2 + DSO_CONSUMPTION} is added incorrectly."


### PR DESCRIPTION
Fix #554
Adresses #540 

**Changes proposed in this pull request**:
- Add Debug messages for pytests: `D2` 
- Fix incorrectly applied minimal renewable share criterion
- Change `D2.prepare_constraint_minimal_renewable_share`, including logging messages and pytest

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)