### PR TITLE
Fix piecharts to display actual project currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - Change logging level of some messages from `logging.info` to `logging.debug` (#555)
 - Move and rename json input files for D0 and D1 tests (`test_data_for_D0.json` to `tests/test_data/inputs_for_D0/mvs_config.json`, `test_data_for_D1.json` to `tests/test_data/inputs_for_D1/mvs_config.json`), add required parameters (#555) 
 - Change requirements/test.txt: `black==19.10b0`, as otherwise there are incompatabilities (#555)
+- `F1.plot_piecharts_of_costs()` now cites costs with currect currency and avoids decimal numbers (#561)
 
 ### Removed
 -
@@ -42,6 +43,7 @@ Here is a template for new release sections
 ### Fixed
 - `C1.check_feedin_tariff()` now also accepts `isinstance(diff, int)` (#552)
 - Feed-in sinks of the DSOs now are capacity-optimized and can actually be used (#555)
+- Graphs of the report now use appropriate currency (#561)
 
 ## [0.4.0] - 2020-09-01
 

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -21,6 +21,7 @@ import oemof
 
 from mvs_eland.utils.constants import (
     PROJECT_DATA,
+    ECONOMIC_DATA,
     LABEL,
     OUTPUT_FOLDER,
 )
@@ -28,6 +29,7 @@ from mvs_eland.utils.constants import (
 from mvs_eland.utils.constants_json_strings import (
     PROJECT_NAME,
     SCENARIO_NAME,
+    CURR,
     KPI,
     ENERGY_CONSUMPTION,
     TIMESERIES,
@@ -1126,7 +1128,14 @@ def plot_piecharts_of_costs(dict_values, file_path=None):
         )
 
         # Title of the pie plot
-        plot_title = kpi_part + str(round(total_for_title, 2)) + "$) " + project_title
+        plot_title = (
+            kpi_part
+            + str(round(total_for_title))
+            + " "
+            + dict_values[ECONOMIC_DATA][CURR]
+            + ") "
+            + project_title
+        )
 
         fig = create_plotly_piechart_fig(
             title_of_plot=plot_title,


### PR DESCRIPTION
Fix #553

**Changes proposed in this pull request**:
- Change `F1.plot_piecharts_of_costs()` now cites costs with currect currency and avoids decimal numbers
- Fix Graphs of the report now use appropriate currency

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x:  Write docstrings to your code
:x:  For new functionalities: Explain in readthedocs
:x:  Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)