### PR TITLE
Fix optimizedAddCap of non-dispatchable sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Here is a template for new release sections
 ### Removed
 -
 ### Fixed
-- optimizedAddCap of non-dispatchable sources: multiply maximumCap by max(timeseries(kWh/kWp)) to fix issue #446 (#498)
+- optimizedAddCap of non-dispatchable sources: multiply maximumCap by max(timeseries(kWh/kWp)) to fix issue #446 (#562, #498)
+-`timeseries_normalized` are calculated for all `timeseries` of non-dispatchable sources now (before only if `optimizeCap==True`) (#562, #498)
 ```
 
 ## [Unreleased]

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1718,6 +1718,8 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
             if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:
                 dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(
                     dict[TIMESERIES_NORMALIZED]
+                logging.debug(
+                    f"Parameter {MAXIMUM_CAP} of asset '{asset_dict[LABEL]}' was divided by the peak value of {TIMESERIES_NORMALIZED} as it did not equal 1. This was done as the aimed constraint is to limit the power, not the flow."
                 )
             # check if maximumCap is greater that installedCap
             if dict[MAXIMUM_CAP][VALUE] < dict[INSTALLED_CAP][VALUE]:

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1714,7 +1714,9 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
         if dict[MAXIMUM_CAP][VALUE] is not None:
             # adapt maximumCap of nocolan-dispatchable sources
             if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:
-                dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(dict[TIMESERIES_NORMALIZED])
+                dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(
+                    dict[TIMESERIES_NORMALIZED]
+                )
             # check if maximumCap is greater that installedCap
             if dict[MAXIMUM_CAP][VALUE] < dict[INSTALLED_CAP][VALUE]:
 

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1713,7 +1713,7 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
         dict = dict_values[group][asset][subasset]
     if MAXIMUM_CAP in dict:
         if dict[MAXIMUM_CAP][VALUE] is not None:
-            # adapt maximumCap of nocolan-dispatchable sources
+            # adapt maximumCap of non-dispatchable sources
             if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:
                 dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(
                     dict[TIMESERIES_NORMALIZED]

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1712,6 +1712,7 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
     else:
         dict = dict_values[group][asset][subasset]
     if MAXIMUM_CAP in dict:
+        # Check if a maximumCap is defined
         if dict[MAXIMUM_CAP][VALUE] is not None:
             # adapt maximumCap of non-dispatchable sources
             if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1718,6 +1718,11 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
             if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:
                 dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(
                     dict[TIMESERIES_NORMALIZED]
+            if (
+                group == ENERGY_PRODUCTION
+                and asset_dict[FILENAME] != None
+                and max(asset_dict[TIMESERIES_NORMALIZED]) != 1
+            ):
                 logging.debug(
                     f"Parameter {MAXIMUM_CAP} of asset '{asset_dict[LABEL]}' was divided by the peak value of {TIMESERIES_NORMALIZED} as it did not equal 1. This was done as the aimed constraint is to limit the power, not the flow."
                 )

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1700,7 +1700,8 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
     asset: str
         asset name
     subasset: str
-        subasset name. Default: None.
+        subasset name.
+        Default: None.
 
     Returns
     -------

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1591,22 +1591,21 @@ def receive_timeseries_from_csv(
             }
         )
 
-        if dict_asset[OPTIMIZE_CAP][VALUE] is True:
-            logging.debug("Normalizing timeseries of %s.", dict_asset[LABEL])
-            dict_asset.update(
-                {
-                    TIMESERIES_NORMALIZED: dict_asset[TIMESERIES]
-                    / dict_asset[TIMESERIES_PEAK][VALUE]
-                }
+        logging.debug("Normalizing timeseries of %s.", dict_asset[LABEL])
+        dict_asset.update(
+            {
+                TIMESERIES_NORMALIZED: dict_asset[TIMESERIES]
+                / dict_asset[TIMESERIES_PEAK][VALUE]
+            }
+        )
+        # just to be sure!
+        if any(dict_asset[TIMESERIES_NORMALIZED].values) > 1:
+            logging.warning(
+                "Error, %s timeseries not normalized, greater than 1.",
+                dict_asset[LABEL],
             )
-            # just to be sure!
-            if any(dict_asset[TIMESERIES_NORMALIZED].values) > 1:
-                logging.warning(
-                    "Error, %s timeseries not normalized, greater than 1.",
-                    dict_asset[LABEL],
-                )
-            if any(dict_asset[TIMESERIES_NORMALIZED].values) < 0:
-                logging.warning("Error, %s timeseries negative.", dict_asset[LABEL])
+        if any(dict_asset[TIMESERIES_NORMALIZED].values) < 0:
+            logging.warning("Error, %s timeseries negative.", dict_asset[LABEL])
 
 
 def treat_multiple_flows(dict_asset, dict_values, parameter):

--- a/src/mvs_eland/C0_data_processing.py
+++ b/src/mvs_eland/C0_data_processing.py
@@ -1708,26 +1708,26 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
 
     """
     if subasset is None:
-        dict = dict_values[group][asset]
+        asset_dict = dict_values[group][asset]
     else:
-        dict = dict_values[group][asset][subasset]
-    if MAXIMUM_CAP in dict:
+        asset_dict = dict_values[group][asset][subasset]
+    if MAXIMUM_CAP in asset_dict:
         # Check if a maximumCap is defined
-        if dict[MAXIMUM_CAP][VALUE] is not None:
+        if asset_dict[MAXIMUM_CAP][VALUE] is not None:
             # adapt maximumCap of non-dispatchable sources
-            if group == ENERGY_PRODUCTION and dict[RENEWABLE_ASSET_BOOL][VALUE] == True:
-                dict[MAXIMUM_CAP][VALUE] = dict[MAXIMUM_CAP][VALUE] / max(
-                    dict[TIMESERIES_NORMALIZED]
             if (
                 group == ENERGY_PRODUCTION
                 and asset_dict[FILENAME] != None
                 and max(asset_dict[TIMESERIES_NORMALIZED]) != 1
             ):
+                asset_dict[MAXIMUM_CAP][VALUE] = asset_dict[MAXIMUM_CAP][VALUE] / max(
+                    asset_dict[TIMESERIES_NORMALIZED]
+                )
                 logging.debug(
                     f"Parameter {MAXIMUM_CAP} of asset '{asset_dict[LABEL]}' was divided by the peak value of {TIMESERIES_NORMALIZED} as it did not equal 1. This was done as the aimed constraint is to limit the power, not the flow."
                 )
             # check if maximumCap is greater that installedCap
-            if dict[MAXIMUM_CAP][VALUE] < dict[INSTALLED_CAP][VALUE]:
+            if asset_dict[MAXIMUM_CAP][VALUE] < asset_dict[INSTALLED_CAP][VALUE]:
 
                 logging.warning(
                     f"The stated maximumCap in {group} {asset} is smaller than the "
@@ -1735,14 +1735,14 @@ def add_maximum_cap(dict_values, group, asset, subasset=None):
                     "For this simulation, the maximumCap will be "
                     "disregarded and not be used in the simulation"
                 )
-                dict[MAXIMUM_CAP][VALUE] = None
+                asset_dict[MAXIMUM_CAP][VALUE] = None
             # check if maximumCao is 0
-            elif dict[MAXIMUM_CAP][VALUE] == 0:
+            elif asset_dict[MAXIMUM_CAP][VALUE] == 0:
                 logging.warning(
                     f"The stated maximumCap of zero in {group} {asset} is invalid."
                     "For this simulation, the maximumCap will be "
                     "disregarded and not be used in the simulation."
                 )
-                dict[MAXIMUM_CAP][VALUE] = None
+                asset_dict[MAXIMUM_CAP][VALUE] = None
     else:
-        dict.update({MAXIMUM_CAP: {VALUE: None, UNIT: dict[UNIT]}})
+        asset_dict.update({MAXIMUM_CAP: {VALUE: None, UNIT: asset_dict[UNIT]}})

--- a/src/mvs_eland/C1_verification.py
+++ b/src/mvs_eland/C1_verification.py
@@ -166,7 +166,7 @@ def check_non_dispatchable_source_time_series(dict_values):
     """
     # go through all non-dispatchable sources
     for key, source in dict_values[ENERGY_PRODUCTION].items():
-        if RENEWABLE_ASSET_BOOL in source and source[RENEWABLE_ASSET_BOOL][VALUE] == True:
+        if TIMESERIES_NORMALIZED in source and source[RENEWABLE_ASSET_BOOL][VALUE] == True:
             # check if values between 0 and 1
             result = check_time_series_values_between_0_and_1(
                 time_series=source[TIMESERIES_NORMALIZED]

--- a/src/mvs_eland/C1_verification.py
+++ b/src/mvs_eland/C1_verification.py
@@ -166,7 +166,10 @@ def check_non_dispatchable_source_time_series(dict_values):
     """
     # go through all non-dispatchable sources
     for key, source in dict_values[ENERGY_PRODUCTION].items():
-        if TIMESERIES_NORMALIZED in source and source[RENEWABLE_ASSET_BOOL][VALUE] == True:
+        if (
+            TIMESERIES_NORMALIZED in source
+            and source[RENEWABLE_ASSET_BOOL][VALUE] == True
+        ):
             # check if values between 0 and 1
             result = check_time_series_values_between_0_and_1(
                 time_series=source[TIMESERIES_NORMALIZED]


### PR DESCRIPTION
This should be merged into PR #498; split up due to insecurities.

**Changes proposed in this pull request**:
- Fix optimizedAddCap of non-dispatchable sources: multiply maximumCap by max(timeseries(kWh/kWp)) to fix issue #446
- `timeseries_normalized` are calculated for all `timeseries` of non-dispatchable sources now (before only if `optimizeCap==True`) 

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
