### PR TITLE
Fix readthedoc for code modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Here is a template for new release sections
 - Move and rename json input files for D0 and D1 tests (`test_data_for_D0.json` to `tests/test_data/inputs_for_D0/mvs_config.json`, `test_data_for_D1.json` to `tests/test_data/inputs_for_D1/mvs_config.json`), add required parameters (#555) 
 - Change requirements/test.txt: `black==19.10b0`, as otherwise there are incompatabilities (#555)
 - `D2.prepare_constraint_minimal_renewable_share`, including logging messages and pytest (#560)
+- Change the import path of the modules for automatic docstrings import in `docs/Code.rst` (#564)
+- Fix the docstrings with math expressions (need to add `r` before the `"""` of the docstring
+) (#564)
 
 ### Removed
 

--- a/docs/Code.rst
+++ b/docs/Code.rst
@@ -5,7 +5,7 @@ Code documentation
 Initialization
 --------------
 
-.. automodule:: src.constants
+.. automodule:: mvs_eland.utils.constants
    :members:
    :undoc-members:
 
@@ -13,81 +13,81 @@ Initialization
    :members:
    :undoc-members:
 
-.. automodule:: src.A0_initialization
+.. automodule:: mvs_eland.A0_initialization
    :members:
    :undoc-members:
 
-.. automodule:: src.A1_csv_to_json
+.. automodule:: mvs_eland.A1_csv_to_json
    :members:
    :undoc-members:
    
 Data input
 ----------
 
-.. automodule:: src.B0_data_input_json
+.. automodule:: mvs_eland.B0_data_input_json
    :members:
    :undoc-members:
 
 Data processing
 ---------------
 
-.. automodule:: src.C0_data_processing
+.. automodule:: mvs_eland.C0_data_processing
    :members:
    :undoc-members:
 
-.. automodule:: src.C1_verification
+.. automodule:: mvs_eland.C1_verification
    :members:
    :undoc-members:
 
-.. automodule:: src.C2_economic_functions
+.. automodule:: mvs_eland.C2_economic_functions
    :members:
    :undoc-members:
 
 Modelling
 ---------
 
-.. automodule:: src.D0_modelling_and_optimization
+.. automodule:: mvs_eland.D0_modelling_and_optimization
    :members:
    :undoc-members:
 
-.. automodule:: src.D1_model_components
+.. automodule:: mvs_eland.D1_model_components
    :members:
    :undoc-members:
 
-.. automodule:: src.D2_model_constraints
+.. automodule:: mvs_eland.D2_model_constraints
    :members:
    :undoc-members:
 
 Evaluation
 ----------
 
-.. automodule:: src.E0_evaluation
+.. automodule:: mvs_eland.E0_evaluation
    :members:
    :undoc-members:
 
-.. automodule:: src.E1_process_results
+.. automodule:: mvs_eland.E1_process_results
    :members:
    :undoc-members:
 
-.. automodule:: src.E2_economics
+.. automodule:: mvs_eland.E2_economics
    :members:
    :undoc-members:
 
-.. automodule:: src.E3_indicator_calculation
+.. automodule:: mvs_eland.E3_indicator_calculation
    :members:
    :undoc-members:
 
-.. automodule:: src.E4_verification_of_constraints
+.. automodule:: mvs_eland.E4_verification_of_constraints
    :members:
    :undoc-members:
 
 Output
 ------
 
-.. automodule:: src.F0_output
+.. automodule:: mvs_eland.F0_output
    :members:
    :undoc-members:
 
-.. automodule:: src.F1_plotting
+.. automodule:: mvs_eland.F1_plotting
    :members:
    :undoc-members:

--- a/docs/files_to_be_displayed/example_docstring.py
+++ b/docs/files_to_be_displayed/example_docstring.py
@@ -22,7 +22,7 @@ def example_function(arg1, argN):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
         here comes the description
     (In case of no return, you can write what the function changes, e.g. updates
     `variable_x` with `y`.)

--- a/src/mvs_eland/A0_initialization.py
+++ b/src/mvs_eland/A0_initialization.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module A0_initialization defines functions to parse user inputs to the MVS simulation.
     - Display welcome message with current version number
     - Parse command line arguments and set default values for MVS parameters if not provided
@@ -8,27 +8,37 @@ Module A0_initialization defines functions to parse user inputs to the MVS simul
 
 Usage from root of repository:
 
-python mvs_tool.py [-h] [-i [PATH_INPUT_FOLDER]] [-ext [{json,csv}]]
-                          [-o [PATH_OUTPUT_FOLDER]]
-                          [-log [{debug,info,error,warning}]] [-f [OVERWRITE]]
-                          [-pdf [PDF_REPORT]] [-png [SAVE_PNG]]
+.. code-block:: bash
+
+    python mvs_tool.py [-h] [-i [PATH_INPUT_FOLDER]] [-ext [{json,csv}]] [-o [PATH_OUTPUT_FOLDER]]
+    [-log [{debug,info,error,warning}]] [-f [OVERWRITE]] [-pdf [PDF_REPORT]] [-png [SAVE_PNG]]
 
 Process MVS arguments
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -i [PATH_INPUT_FOLDER]
-                        path to the input folder
-  -ext [{json,csv}]     type (json or csv) of the input files (default: 'json'
-  -o [PATH_OUTPUT_FOLDER]
-                        path to the output folder for the simulation's results
-  -log [{debug,info,error,warning}]
-                        level of logging in the console
-  -f [OVERWRITE]        overwrite the output folder if True (default: False)
-  -pdf [PDF_REPORT]     generate a pdf report of the simulation if True
-                        (default: False)
-  -png [SAVE_PNG]       generate png figures of the simulation in the
-                        output_folder if True (default: False)
+    -h, --help
+        show this help message and exit
+
+    -i [PATH_INPUT_FOLDER]
+        path to the input folder
+
+    -ext [{json,csv}]
+        type (json or csv) of the input files (default: 'json')
+
+    -o [PATH_OUTPUT_FOLDER]
+        path to the output folder for the simulation's results
+
+    -log [{debug,info,error,warning}]
+        level of logging in the console
+
+    -f [OVERWRITE]
+        overwrite the output folder if True (default: False)
+
+    -pdf [PDF_REPORT]
+        generate a pdf report of the simulation if True (default: False)
+
+    -png [SAVE_PNG]
+        generate png figures of the simulation in the output_folder if True (default: False)
 
 """
 

--- a/src/mvs_eland/A0_initialization.py
+++ b/src/mvs_eland/A0_initialization.py
@@ -280,14 +280,15 @@ def process_user_arguments(
         (Optional) Can force tool to replace existing output folder (command line "-f")
     :param pdf_report:
         (Optional) Can generate an automatic pdf report of the simulation's results (Command line "-pdf")
-    :param: save_png:
+    :param save_png:
         (Optional) Can generate png figures with the simulation's results (Command line "-png")
     :param display_output:
         (Optional) Determines which messages are used for terminal output (command line "-log")
-            "debug": All logging messages
-            "info": All informative messages and warnings (default)
-            "warning": All warnings
-            "error": Only errors
+        Allowed values are
+        "debug": All logging messages,
+        "info": All informative messages and warnings (default),
+        "warning": All warnings,
+        "error": Only errors,
     :param lp_file_output:
         Save linear equation system generated as lp file
     :param welcome_text:

--- a/src/mvs_eland/A1_csv_to_json.py
+++ b/src/mvs_eland/A1_csv_to_json.py
@@ -504,7 +504,7 @@ def check_for_official_extra_parameters(
 
     Returns
     -------
-    Updated parameters list and updated dataframe and updated :pandas:`pandas.DataFrame<frame>`
+    Updated parameters list and updated dataframe and updated :class:`pandas.DataFrame<frame>`
     The function through a warning if a new parameter is not defined in the csv but exists inf
     the official_extra_parameters. The parameter will then be set to it's default value.
     """

--- a/src/mvs_eland/C2_economic_functions.py
+++ b/src/mvs_eland/C2_economic_functions.py
@@ -28,7 +28,7 @@ from mvs_eland.utils.constants_json_strings import (
 
 # annuity factor to calculate present value of cash flows
 def annuity_factor(project_life, discount_factor):
-    """
+    r"""
     Calculates the annuity factor, which in turn in used to calculate the present value of annuities (instalments)
 
     Parameters
@@ -36,21 +36,25 @@ def annuity_factor(project_life, discount_factor):
 
     project_life: int
         time period over which the costs of the system occur
-
     discount_factor: float
         weighted average cost of capital, which is the after-tax average cost of various capital sources
 
     Returns
     -------
-    financial value "annuity factor". Dividing a present cost by tha annuity factor returns its annuity, multiplying an annuity with the annuity factor returns its present value
+    annuity_factor: float
+        financial value "annuity factor".
+        Dividing a present cost by tha annuity factor returns its annuity,
+        multiplying an annuity with the annuity factor returns its present value
 
 
     Notes
     -----
 
-    .. math::     annuity factor = \frac{1}{discount factor} - \frac{1}{
-        discountfactor \cdot (1 + discount factor) ^ project life}
-    )
+    .. math::
+
+        annuity factor = \frac{1}{discount factor} - \frac{1}{
+        discountfactor \cdot (1 + discount factor)^{project life}}
+
     """
     annuity_factor = 1 / discount_factor - 1 / (
         discount_factor * (1 + discount_factor) ** project_life
@@ -427,15 +431,16 @@ def get_lifetime_price_dispatch_one_value(dispatch_price, economic_data):
 
 
 def get_lifetime_price_dispatch_list(dispatch_price, economic_data):
-    """
+    r"""
     Determines the lifetime dispatch price in case that the dispatch price is a list.
 
     The dispatch_price can be a list when for example if there are two input flows to a component, eg. water and electricity.
     There should be a lifetime_price_dispatch for each of them.
 
     .. math::
-        lifetime_price_dispatch_i = DISPATCH_PRICE_i \cdot ANNUITY_FACTOR \forall i
-        with i for all list entries
+        lifetime\_price\_dispatch\_i = DISPATCH\_PRICE\_i \cdot ANNUITY\_FACTOR \forall i
+
+    with :math:`i` for all list entries
 
     Parameters
     ----------
@@ -477,17 +482,16 @@ def get_lifetime_price_dispatch_list(dispatch_price, economic_data):
 
 
 def get_lifetime_price_dispatch_timeseries(dispatch_price, economic_data):
-    """
+    r"""
     Calculates the lifetime price dispatch for a timeseries.
-
     The dispatch_price can be a timeseries, eg. in case that there is an hourly pricing.
-
     .. math::
-        lifetime_price_dispatch(t) = DISPATCH_PRICE(t) \cdot ANNUITY_FACTOR \forall t
+
+        lifetime\_price\_dispatch(t) = DISPATCH\_PRICE(t) \cdot ANNUITY\_FACTOR \forall t
 
     Parameters
     ----------
-    dispatch_price: pd.Series
+    dispatch_price: :class:`pandas.Series`
         Dispatch price as a timeseries (eg. electricity prices)
 
     economic_data: dict
@@ -495,13 +499,15 @@ def get_lifetime_price_dispatch_timeseries(dispatch_price, economic_data):
 
     Returns
     -------
-    Lifetime dispatch price that the asset will be updated with
+    lifetime_price_dispatch: float
+        Lifetime dispatch price that the asset will be updated with
 
     Notes
     -----
     Tested with
-    - test_determine_lifetime_price_dispatch_as_timeseries()
-    - test_get_lifetime_price_dispatch_timeseries()
+        - test_determine_lifetime_price_dispatch_as_timeseries()
+        - test_get_lifetime_price_dispatch_timeseries()
+
     """
 
     lifetime_price_dispatch = dispatch_price.multiply(

--- a/src/mvs_eland/D2_model_constraints.py
+++ b/src/mvs_eland/D2_model_constraints.py
@@ -73,7 +73,7 @@ def add_constraints(local_energy_system, dict_values, dict_model):
 
 
 def constraint_minimal_renewable_share(model, dict_values, dict_model):
-    """
+    r"""
     Resulting in an energy system adhering to a minimal renewable factor.
 
     Please be aware that the renewable factor that has to adhere to the minimal renewable factor is not the one of one specific sector,

--- a/src/mvs_eland/E1_process_results.py
+++ b/src/mvs_eland/E1_process_results.py
@@ -572,7 +572,7 @@ def convert_demand_to_dataframe(dict_values):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
     # Creating a dataframe for the demands
@@ -630,7 +630,7 @@ def convert_components_to_dataframe(dict_values):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
 
@@ -700,7 +700,7 @@ def convert_scalar_matrix_to_dataframe(dict_values):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
 
@@ -739,7 +739,7 @@ def convert_cost_matrix_to_dataframe(dict_values):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
 
@@ -779,7 +779,7 @@ def convert_costs_to_dataframe(dict_values):
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
     # Get the cost matrix from the results JSON file into a pandas DF
@@ -813,7 +813,7 @@ def convert_scalars_to_dataframe(dict_values):
 
     Returns
     -------
-    kpi_scalars_dataframe: :pandas:`pandas.DataFrame<frame>`
+    kpi_scalars_dataframe: :class:`pandas.DataFrame<frame>`
         Dataframe to be displayed as a table in the report
 
     Notes
@@ -839,7 +839,7 @@ def convert_scalars_to_dataframe(dict_values):
 
 def get_units_of_cost_matrix_entries(dict_economic, kpi_list):
     """
-    Determines the units of the costs KPI to be stored to :pandas: DataFrame.
+    Determines the units of the costs KPI to be stored to :class: DataFrame.
 
     Parameters
     ----------
@@ -852,7 +852,7 @@ def get_units_of_cost_matrix_entries(dict_economic, kpi_list):
     Returns
     -------
     unit_list: list
-        List of units for the :pandas: DataFrame to be created
+        List of units for the :class: DataFrame to be created
     """
 
     unit_list = []

--- a/src/mvs_eland/E2_economics.py
+++ b/src/mvs_eland/E2_economics.py
@@ -462,8 +462,9 @@ def all_list_in_dict(dict_asset, list):
 
 
 def lcoe_assets(dict_asset, asset_group):
-    """
+    r"""
     Calculates the levelized cost of electricity (lcoe) of each asset. [Follow this link for information](docs/MVS_Outputs.rst)
+
     Parameters
     ----------
     dict_asset: dict
@@ -480,9 +481,10 @@ def lcoe_assets(dict_asset, asset_group):
     Notes
     -----
 
-    ..:math: LCOE_ASSET = \frac{A}{ E_{throughput} }
+    .. math::
 
-    If  E_{throughput} == 0, LCOE_ASSET = 0.
+        LCOE\_ASSET = \frac{A}{ E_{throughput} } \\
+        \textrm{If } E_{throughput} = 0, LCOE\_ASSET = 0
 
     """
 

--- a/src/mvs_eland/E3_indicator_calculation.py
+++ b/src/mvs_eland/E3_indicator_calculation.py
@@ -422,7 +422,7 @@ def equation_degree_of_autonomy():
 
 
 def add_degree_of_sector_coupling(dict_values):
-    """
+    r"""
     Determines the aggregated flows in between the sectors and the Degree of Sector Coupling.
 
     Takes into account the value of different energy carriers.
@@ -436,9 +436,9 @@ def add_degree_of_sector_coupling(dict_values):
     -------
     Energy equivalent of total conversion flows:
 
-    .. math:: E_{conversion,eq} = \sum_{i}{E_{conversion} (i)⋅w_i}
-
-            with i are conversion assets
+    .. math::
+        E_{conversion,eq} = \sum_{i}{E_{conversion} (i) \cdot w_i}
+        with i are conversion assets
 
     """
     # todo actually only flows that transform an energy carrier from oone energy vector to the next should be added

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -93,12 +93,12 @@ def extract_plot_data_and_title(dict_values, df_dem=None):
     dict_values: dict
         output values of MVS
 
-    df_dem: :pandas:`pandas.DataFrame<frame>`
+    df_dem: :class:`pandas.DataFrame<frame>`
         summarized demand information for each demand
 
     Returns
     -------
-    :pandas:`pandas.DataFrame<frame>`
+    :class:`pandas.DataFrame<frame>`
 
     """
     if df_dem is None:
@@ -538,7 +538,7 @@ def create_plotly_line_fig(
 
     Returns
     -------
-    fig :plotly:`plotly.graph_objs.Figure`
+    fig :class:`plotly.graph_objs.Figure`
         figure object
     """
     fig = go.Figure()
@@ -615,7 +615,7 @@ def plot_timeseries(
 
     Returns
     -------
-    Dict with html DOM id for the figure as key and :plotly:`plotly.graph_objs.Figure` as value
+    Dict with html DOM id for the figure as key and :class:`plotly.graph_objs.Figure` as value
     """
 
     df_dem = convert_demand_to_dataframe(dict_values)
@@ -700,7 +700,7 @@ def create_plotly_barplot_fig(
 
     Returns
     -------
-    fig: :plotly:`plotly.graph_objs.Figure`
+    fig: :class:`plotly.graph_objs.Figure`
         figure object
     """
     fig = go.Figure()
@@ -772,7 +772,7 @@ def plot_optimized_capacities(
 
     Returns
     -------
-    Dict with html DOM id for the figure as key and :plotly:`plotly.graph_objs.Figure` as value
+    Dict with html DOM id for the figure as key and :class:`plotly.graph_objs.Figure` as value
     """
 
     # Add dataframe to hold all the KPIs and optimized additional capacities
@@ -827,7 +827,7 @@ def create_plotly_flow_fig(
 
     Parameters
     ----------
-    df_plots_data: :pandas:`pandas.DataFrame<frame>`
+    df_plots_data: :class:`pandas.DataFrame<frame>`
         dataFrame with timeseries of the asset's energy flow
     x_legend: str
         Default: None
@@ -852,7 +852,7 @@ def create_plotly_flow_fig(
 
     Returns
     -------
-    fig: :plotly:`plotly.graph_objs.Figure`
+    fig: :class:`plotly.graph_objs.Figure`
         figure object
     """
 
@@ -921,7 +921,7 @@ def plot_flows(dict_values, file_path=None):
     Returns
     -------
     pie_plots: dict
-       Dict with html DOM id for the figure as keys and :plotly:`plotly.graph_objs.Figure` as values
+       Dict with html DOM id for the figure as keys and :class:`plotly.graph_objs.Figure` as values
     """
     buses_list = list(dict_values[OPTIMIZED_FLOWS].keys())
     multi_plots = {}
@@ -989,7 +989,7 @@ def create_plotly_piechart_fig(
 
     Returns
     -------
-    fig: :plotly:`plotly.graph_objs.Figure`
+    fig: :class:`plotly.graph_objs.Figure`
         figure object
     """
 
@@ -1060,7 +1060,7 @@ def plot_piecharts_of_costs(dict_values, file_path=None):
     Returns
     -------
     pie_plots: dict
-       Dict with html DOM id for the figure as keys and :plotly:`plotly.graph_objs.Figure` as values
+       Dict with html DOM id for the figure as keys and :class:`plotly.graph_objs.Figure` as values
     """
 
     df_pie_data = convert_costs_to_dataframe(dict_values)

--- a/src/mvs_eland/F2_autoreport.py
+++ b/src/mvs_eland/F2_autoreport.py
@@ -172,7 +172,7 @@ def make_dash_data_table(df, title=None):
 
     Parameters
     ----------
-    df: :pandas:`pandas.DataFrame<frame>`
+    df: :class:`pandas.DataFrame<frame>`
         This dataframe holds the data from which the dash table is to be created.
 
     title: str
@@ -352,7 +352,7 @@ def insert_plotly_figure(
 
     Parameters
     ----------
-    fig: :plotly:`plotly.graph_objs.Figure`
+    fig: :class:`plotly.graph_objs.Figure`
         figure object
 
     id_plot: str

--- a/src/mvs_eland/utils/constants_json_strings.py
+++ b/src/mvs_eland/utils/constants_json_strings.py
@@ -1,9 +1,10 @@
 """
 Defines the strings of different json parameters
-Not defining parameters as strings can be helpful, ig. if
-    if string in dict_values
-Is used, where typos can be very bad for future handling.
+Using variables rather than strings is helpful for typo prevention. A typo in a variable will
+raise an error where the variable was misspelled, whereas a typo in a string (dictionnary key)
+do not nessarily raise an error immediately, making the typo harder to fix.
 """
+
 #####################
 # 1st level of json #
 #####################


### PR DESCRIPTION
Fix #563 

**Changes proposed in this pull request**:
- Change the import path of the modules for automatic docstrings import in `docs/Code.rst`
- Fix the docstrings with math expressions (need to add `r` before the `"""` of the docstring)

The following steps were realized, as well (if applies):
- [ ] For new functionalities: Explain in readthedocs
- [ ] Update the CHANGELOG.md

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
