### PR TITLE
Fix/plots labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,10 @@ Here is a template for new release sections
 - Change the import path of the modules for automatic docstrings import in `docs/Code.rst` (#564)
 - Fix the docstrings with math expressions (need to add `r` before the `"""` of the docstring
 ) (#564)
+- Rename the function in F1 module `plot_flows` to `plot_instant_power` (#567)
+- Change flow to power in the instanteous power figures (#567)
 
 ### Removed
-
 
 ### Fixed
 - `C1.check_feedin_tariff()` now also accepts `isinstance(diff, int)` (#552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 ### Added
 - Evaluation of excess energy for each of the energy carriers and for the whole system. The excess per sector and their energy equivalent may currently be faulty (comp. issue #559) (#555)
 - Debug messages for pytests: `C0`, `D2` (#555, #560)
+- Labels on capacity barplot bars (#567)
 
 ### Changed
 - `C1.total_demand_each_sector()` to `C1.total_demand_and_excess_each_sector()`, now also evaluating the excess energy flows (#555)

--- a/src/mvs_eland/F0_output.py
+++ b/src/mvs_eland/F0_output.py
@@ -103,7 +103,7 @@ def evaluate_dict(dict_values, path_pdf_report=None, path_png_figs=None):
         )
 
         # plot power flows in the energy system
-        F1_plots.plot_flows(dict_values, file_path=path_png_figs)
+        F1_plots.plot_instant_power(dict_values, file_path=path_png_figs)
 
         # plot optimal capacities if there are optimized assets
         F1_plots.plot_optimized_capacities(dict_values, file_path=path_png_figs)

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -29,6 +29,7 @@ from mvs_eland.utils.constants_json_strings import (
     PROJECT_NAME,
     SCENARIO_NAME,
     KPI,
+    UNIT,
     ENERGY_CONSUMPTION,
     TIMESERIES,
     DISPATCHABILITY,
@@ -661,6 +662,7 @@ def create_plotly_barplot_fig(
     y_data,
     plot_title=None,
     trace_name="",
+    legends=None,
     x_axis_name=None,
     y_axis_name=None,
     file_name="barplot.png",
@@ -685,6 +687,10 @@ def create_plotly_barplot_fig(
         Sets the trace name. The trace name appear as the legend item and on hover.
         Default: ""
 
+    legends: list, or pandas series
+        The list of the text written within the bars and on hover below the trace_name
+        Default: None
+
     x_axis_name: str
         Default: None
 
@@ -708,9 +714,14 @@ def create_plotly_barplot_fig(
     styling_dict = get_fig_style_dict()
     styling_dict["mirror"] = True
 
+    opts = {}
+    if legends is not None:
+        opts.update(dict(text=legends, textposition="auto"))
+
     fig.add_trace(
         go.Bar(
-            name=trace_name, x=x_data, y=y_data, marker_color=px.colors.qualitative.D3,
+            name=trace_name, x=x_data, y=y_data,
+            marker_color=px.colors.qualitative.D3,**opts
         )
     )
 
@@ -784,13 +795,16 @@ def plot_optimized_capacities(
 
     x_values = []
     y_values = []
+    legends = []
 
-    for kpi, cap in zip(
-        list(df_capacities[LABEL]), list(df_capacities[OPTIMIZED_ADD_CAP])
+    for kpi, cap, unit in zip(
+        list(df_capacities[LABEL]), list(df_capacities[OPTIMIZED_ADD_CAP]), list(df_capacities[
+                                                                                     UNIT])
     ):
         if cap > 0:
             x_values.append(kpi)
             y_values.append(cap)
+            legends.append("{:.0f} {}".format(cap, unit))
 
     # Title to add to plot titles
     project_title = ": {}, {}".format(
@@ -803,8 +817,9 @@ def plot_optimized_capacities(
     fig = create_plotly_barplot_fig(
         x_data=x_values,
         y_data=y_values,
-        plot_title="Optimal additional capacities (kW/kWh/kWp)" + project_title,
+        plot_title="Optimal additional capacities" + project_title,
         trace_name="capacities",
+        legends=legends,
         x_axis_name="Items",
         y_axis_name="Capacities",
         file_name=name_file,

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -920,7 +920,7 @@ def plot_flows(dict_values, file_path=None):
 
     Returns
     -------
-    pie_plots: dict
+    multi_plots: dict
        Dict with html DOM id for the figure as keys and :class:`plotly.graph_objs.Figure` as values
     """
     buses_list = list(dict_values[OPTIMIZED_FLOWS].keys())
@@ -929,7 +929,7 @@ def plot_flows(dict_values, file_path=None):
         comp_id = bus + "-plot"
         title = (
             bus
-            + " flows in LES: "
+            + " power in LES: "
             + dict_values[PROJECT_DATA][PROJECT_NAME]
             + ", "
             + dict_values[PROJECT_DATA][SCENARIO_NAME]
@@ -942,10 +942,10 @@ def plot_flows(dict_values, file_path=None):
         fig = create_plotly_flow_fig(
             df_plots_data=df_data,
             x_legend="Time",
-            y_legend=bus + " flow in kWh",
+            y_legend=bus + " in kW",
             plot_title=title,
             file_path=file_path,
-            file_name=bus + "_flow.png",
+            file_name=bus + "_power.png",
         )
         if file_path is None:
             multi_plots[comp_id] = fig

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -906,8 +906,8 @@ def create_plotly_flow_fig(
     return fig
 
 
-def plot_flows(dict_values, file_path=None):
-    """Plotting timeseries of each assets' flow of the energy system
+def plot_instant_power(dict_values, file_path=None):
+    """Plotting timeseries of instantaneous power for each assets within the energy system
 
     Parameters
     ----------

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -804,6 +804,8 @@ def plot_optimized_capacities(
         if cap > 0:
             x_values.append(kpi)
             y_values.append(cap)
+            if unit == "?":
+                unit = "kW"
             legends.append("{:.0f} {}".format(cap, unit))
 
     # Title to add to plot titles

--- a/src/mvs_eland/F1_plotting.py
+++ b/src/mvs_eland/F1_plotting.py
@@ -720,8 +720,11 @@ def create_plotly_barplot_fig(
 
     fig.add_trace(
         go.Bar(
-            name=trace_name, x=x_data, y=y_data,
-            marker_color=px.colors.qualitative.D3,**opts
+            name=trace_name,
+            x=x_data,
+            y=y_data,
+            marker_color=px.colors.qualitative.D3,
+            **opts
         )
     )
 
@@ -798,8 +801,9 @@ def plot_optimized_capacities(
     legends = []
 
     for kpi, cap, unit in zip(
-        list(df_capacities[LABEL]), list(df_capacities[OPTIMIZED_ADD_CAP]), list(df_capacities[
-                                                                                     UNIT])
+        list(df_capacities[LABEL]),
+        list(df_capacities[OPTIMIZED_ADD_CAP]),
+        list(df_capacities[UNIT]),
     ):
         if cap > 0:
             x_values.append(kpi)

--- a/src/mvs_eland/F2_autoreport.py
+++ b/src/mvs_eland/F2_autoreport.py
@@ -74,7 +74,7 @@ from mvs_eland.F1_plotting import (
     plot_timeseries,
     plot_piecharts_of_costs,
     plot_optimized_capacities,
-    plot_flows,
+    plot_instant_power,
 )
 
 # TODO link this to the version and date number @Bachibouzouk
@@ -475,7 +475,7 @@ def ready_flows_plots(dict_values, only_print=False):
         List containing the assets' timeseries plots as dash components
     """
 
-    figs = plot_flows(dict_values)
+    figs = plot_instant_power(dict_values)
     multi_plots = [
         insert_plotly_figure(fig, id_plot=comp_id, print_only=only_print)
         for comp_id, fig in figs.items()


### PR DESCRIPTION
Fix #557 

**Changes proposed in this pull request**:
- Rename the function in F1 module `plot_flows` to `plot_instant_power`
- Change flow to power in the instanteous power figures
- Labels on capacity barplot bars

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
