### PR TITLE
Improve assert error msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Here is a template for new release sections
 - Instruction to install graphviz on windows in `docs/troubleshooting.rst` (#572)
 ### Changed
 - Modify `setup.py` to upload the code as package on pypi.org (#570)
+- Improve message when the `tests/test_input_folder_parameters.py` fails (#578)
+
 ### Removed
 -
 ### Fixed

--- a/tests/test_input_folder_parameters.py
+++ b/tests/test_input_folder_parameters.py
@@ -70,6 +70,8 @@ def test_input_folder_json_file_have_required_parameters(input_folder):
     """
     if os.path.exists(os.path.join(input_folder, JSON_FNAME)):
         comparison = compare_input_parameters_with_reference(input_folder, ext=JSON_EXT)
-        assert (
-            MISSING_PARAMETERS_KEY not in comparison
-        ), f"In path {input_folder}, the key {MISSING_PARAMETERS_KEY} is included."
+        assert MISSING_PARAMETERS_KEY not in comparison, (
+            f"In path {input_folder}, the following parameters are missing:"
+            f" {MISSING_PARAMETERS_KEY} is included: "
+            + str(comparison[MISSING_PARAMETERS_KEY])
+        )

--- a/tests/test_input_folder_parameters.py
+++ b/tests/test_input_folder_parameters.py
@@ -9,6 +9,7 @@ from _constants import (
     JSON_FNAME,
     MISSING_PARAMETERS_KEY,
     EXTRA_PARAMETERS_KEY,
+    CSV_ELEMENTS,
 )
 from mvs_eland.utils import (
     find_csv_input_folders,
@@ -29,14 +30,21 @@ def test_input_folder_csv_files_have_required_parameters(input_folder):
     extra parameters besides the required ones
     """
     comparison = compare_input_parameters_with_reference(input_folder, ext=CSV_EXT)
-    if MISSING_PARAMETERS_KEY not in comparison:
-        assert True
-    else:
+    if MISSING_PARAMETERS_KEY in comparison:
         for k in comparison[MISSING_PARAMETERS_KEY].keys():
             for el in comparison[MISSING_PARAMETERS_KEY][k]:
-                assert (
-                    el in EXTRA_CSV_PARAMETERS
-                ), f"Key {el} is not in {EXTRA_PARAMETERS_KEY}, but is in {MISSING_PARAMETERS_KEY} in the folder {input_folder}."
+                try:
+                    assert el in EXTRA_CSV_PARAMETERS
+                except AssertionError:
+                    raise AssertionError(
+                        f"Parameter '{el}' is missing in you csv input files although it is required. It "
+                        f"should be added in the appropriate file of the folder '{input_folder}"
+                        f"/{CSV_ELEMENTS}' or listed in the dict 'EXTRA_CSV_PARAMETERS' in "
+                        f"src/mvs_eland/utils/constants.py. The csv required parameters are listed in "
+                        f"the dict 'REQUIRED_CSV_PARAMETERS' in the aforementionned constant.py "
+                        f"file.\n\nSee previous exception in the pytest log for more details on "
+                        f"this error."
+                    )
 
     if TEMPLATE_INPUT_FOLDER in input_folder:
         if EXTRA_PARAMETERS_KEY in comparison:

--- a/tests/test_input_folder_parameters.py
+++ b/tests/test_input_folder_parameters.py
@@ -71,7 +71,6 @@ def test_input_folder_json_file_have_required_parameters(input_folder):
     if os.path.exists(os.path.join(input_folder, JSON_FNAME)):
         comparison = compare_input_parameters_with_reference(input_folder, ext=JSON_EXT)
         assert MISSING_PARAMETERS_KEY not in comparison, (
-            f"In path {input_folder}, the following parameters are missing:"
-            f" {MISSING_PARAMETERS_KEY} is included: "
+            f"In path {input_folder}/{JSON_FNAME}, the following parameters are missing:"
             + str(comparison[MISSING_PARAMETERS_KEY])
         )

--- a/tests/test_input_folder_parameters.py
+++ b/tests/test_input_folder_parameters.py
@@ -50,9 +50,15 @@ def test_input_folder_csv_files_have_required_parameters(input_folder):
         if EXTRA_PARAMETERS_KEY in comparison:
             for k in comparison[EXTRA_PARAMETERS_KEY].keys():
                 for el in comparison[EXTRA_PARAMETERS_KEY][k]:
-                    assert el in EXTRA_CSV_PARAMETERS
-        else:
-            assert True
+                    try:
+                        assert el in EXTRA_CSV_PARAMETERS
+                    except AssertionError:
+                        raise AssertionError(
+                            f"\n\nParameter '{el}' is an extra parameter in the file '{input_folder}/"
+                            f"{CSV_ELEMENTS}/{k}'. The '{TEMPLATE_INPUT_FOLDER}' folder should only "
+                            f"contain the required parameters and no extra parameters.\n\nSee "
+                            f"previous exception in the pytest log for more details on this error."
+                        )
 
 
 @pytest.mark.parametrize("input_folder", TEST_JSON_INPUT_FOLDERS)

--- a/tests/test_input_folder_parameters.py
+++ b/tests/test_input_folder_parameters.py
@@ -38,7 +38,7 @@ def test_input_folder_csv_files_have_required_parameters(input_folder):
                 except AssertionError:
                     raise AssertionError(
                         f"Parameter '{el}' is missing in you csv input files although it is required. It "
-                        f"should be added in the appropriate file of the folder '{input_folder}"
+                        f"should be added in the '{k}.csv' file of the folder '{input_folder}"
                         f"/{CSV_ELEMENTS}' or listed in the dict 'EXTRA_CSV_PARAMETERS' in "
                         f"src/mvs_eland/utils/constants.py. The csv required parameters are listed in "
                         f"the dict 'REQUIRED_CSV_PARAMETERS' in the aforementionned constant.py "


### PR DESCRIPTION
Addresses part of #540 

**Changes proposed in this pull request**:
- Write explicit test failure messages hinting to the developer what is the meta cause of the test failure

The following steps were realized, as well (if applies):
- [x] Write docstrings to your code
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
