### PR TITLE
Include assert message in contribute and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ The following steps were realized, as well (if applies):
 - [ ] Use in-line comments to explain your code
 - [ ] Write docstrings to your code
 - [ ] For new functionalities: Explain in readthedocs
-- [ ] Write test(s) for your new patch of code
+- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
 - [ ] Update the CHANGELOG.md
 - [ ] Apply black (`black . --exclude docs/`)
 - [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Fix #Issue
 
 The following steps were realized, as well (if applies):
 - [ ] Use in-line comments to explain your code
-- [ ] Write docstrings to your code
+- [ ] Write docstrings to your code ([example docstring](https://mvs-eland.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
 - [ ] For new functionalities: Explain in readthedocs
 - [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
 - [ ] Update the CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,13 @@ Here is a template for new release sections
 
 ### Added
 - Instruction to install graphviz on windows in `docs/troubleshooting.rst` (#572)
+
+
 ### Changed
 - Modify `setup.py` to upload the code as package on pypi.org (#570)
 - Improve message when the `tests/test_input_folder_parameters.py` fails (#578)
+- Modify PR template to precise to add assert message and link to example docstring 
+- Update CONTRIBUTING to add a "Write test for your code" section before the "Run tests locally" one (#579)
 
 ### Removed
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ When you test with `assert` you can add a string message which will be displayed
  fails (`assert <condition>, <string message>`). It could be very useful to understand what exactly
  went wrong in the test for a developer 6 months from now.
  If you are testing a function in a module, it would be nice to indicate in the docstring of this
-  function (under the section `Notes` that this test exist!
+  function (under the section `Notes`) that this test exist, cf [example docstring](https://mvs-eland.readthedocs.io/en/latest/Developing.html#format-of-docstrings)!
 
 
 #### Step 3.2: Run tests locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,22 @@ git push
 ```
 If your branch does not exist on the remote server yet, git will provide you with instructions, simply follow them.
 
+#### Step 3.1: Write test for your code
 
-#### Step 3: Run tests locally
+It is important to write some test(s) to test that the feature you introduce works the way you want it to. In future development, your test(s) could always be ran an ensure your feature still works properly
+
+Look at the files existing in the `tests` folder if the test for your new feature could be placed
+ in one of the existing test modules. If not, you can create your own module (the only requirement
+  is that it must starts with `test_`).
+
+When you test with `assert` you can add a string message which will be displayed if the test
+ fails (`assert <condition>, <string message>`). It could be very useful to understand what exactly
+ went wrong in the test for a developer 6 months from now.
+ If you are testing a function in a module, it would be nice to indicate in the docstring of this
+  function (under the section `Notes` that this test exist!
+
+
+#### Step 3.2: Run tests locally
 
 To install all packages required for the integration tests locally (if not done yet):
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If your branch does not exist on the remote server yet, git will provide you wit
 
 #### Step 3.1: Write test for your code
 
-It is important to write some test(s) to test that the feature you introduce works the way you want it to. In future development, your test(s) could always be ran an ensure your feature still works properly
+It is important to write some test(s) to test that the feature you introduce works the way you want it to. In future development, your test(s) could always be ran to ensure your feature still works properly.
 
 Look at the files existing in the `tests` folder if the test for your new feature could be placed
  in one of the existing test modules. If not, you can create your own module (the only requirement

--- a/docs/files_to_be_displayed/example_docstring.py
+++ b/docs/files_to_be_displayed/example_docstring.py
@@ -38,6 +38,8 @@ def example_function(arg1, argN):
         P: power [W], :math:`\rho`: density [kg/m³], d: diameter [m],
         v: wind speed [m/s], cp: power coefficient
 
+    You can also indicate here which tests are covering this function
+
     References
     ----------
     .. [1] paper 1

--- a/docs/files_to_be_displayed/example_docstring.py
+++ b/docs/files_to_be_displayed/example_docstring.py
@@ -38,7 +38,9 @@ def example_function(arg1, argN):
         P: power [W], :math:`\rho`: density [kg/m³], d: diameter [m],
         v: wind speed [m/s], cp: power coefficient
 
-    You can also indicate here which tests are covering this function
+    You can also indicate here which tests are covering this function:
+    This function is tested with:
+    - tests.test_example_function()
 
     References
     ----------


### PR DESCRIPTION
Fix #540 

**Changes proposed in this pull request**:
- Modify PR template to precise to add assert message and link to example docstring
- Update CONTRIBUTING to add a "Write test for your code" section before the "Run tests locally" one

The following steps were realized, as well (if applies):
- [x] Write docstrings to your code
- [x] For new functionalities: Explain in readthedocs
- [x] Update the CHANGELOG.md


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/mvs_eland/blob/dev/CONTRIBUTING.md).*<sub>
